### PR TITLE
feat: validated phone number input with searchable country selector

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "19.2.3",
         "react-hot-toast": "^2.6.0",
         "react-icons": "^5.6.0",
+        "react-phone-number-input": "^3.4.16",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.11"
       },
@@ -102,7 +103,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -662,7 +662,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1848,7 +1847,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3882,7 +3880,6 @@
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3893,7 +3890,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3904,7 +3900,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3968,7 +3963,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4508,7 +4502,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4994,7 +4987,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5142,6 +5134,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -5427,6 +5425,12 @@
         }
       }
     },
+    "node_modules/country-flag-icons": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.17.tgz",
+      "integrity": "sha512-Nmik0289ZVZSI3c7mJR/amg6DyY7Z59b0sTFSKayeX72mHfPzCPJygwJs2pYgQULzuAyWeCUgwAJ+Dq8OR+JFw==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5459,8 +5463,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6039,7 +6042,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6225,7 +6227,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6545,7 +6546,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7361,7 +7361,6 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7471,6 +7470,27 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/input-format": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.14.tgz",
+      "integrity": "sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.1.0",
+        "react-dom": ">=18.1.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8151,7 +8171,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8310,6 +8329,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
+      "integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -8649,7 +8674,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9146,7 +9170,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9699,7 +9722,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9885,7 +9907,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9895,7 +9916,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9933,8 +9953,24 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-phone-number-input": {
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.4.16.tgz",
+      "integrity": "sha512-ix1+SIyGuLxnlAeW+XQNhwOmmDd4Zmr6Ng1eQl0E2XS8xIuue3gdZeBG4LGTMjTIFneOTO9pUPL+AEDhV6+r+A==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.5.1",
+        "country-flag-icons": "^1.6.14",
+        "input-format": "^0.3.14",
+        "libphonenumber-js": "^1.12.37",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -11116,7 +11152,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11374,7 +11409,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11976,7 +12010,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-dom": "19.2.3",
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.6.0",
+    "react-phone-number-input": "^3.4.16",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.11"
   },

--- a/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
+++ b/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
@@ -9,6 +9,7 @@ import {
   type Medication,
 } from "@/store/prescriptionStore";
 import axios from "axios";
+import PhoneInputField, { isValidPhoneNumber } from "@/components/PhoneInputField";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -686,7 +687,7 @@ export default function AddPrescriptionPage() {
       e.patientName = "Name must be at least 2 characters.";
     if (!form.age || isNaN(Number(form.age))) e.age = "Age is required.";
     if (!form.sex) e.sex = "Please select a gender.";
-    if (!form.mobile.trim()) e.mobile = "Mobile number is required.";
+    if (!form.mobile || !isValidPhoneNumber(form.mobile)) e.mobile = "Enter a valid mobile number.";
     if (!form.chiefComplaints.some((c) => c.trim()))
       e.chiefComplaints = "Add at least one C/C.";
     setErrors(e);
@@ -858,14 +859,12 @@ export default function AddPrescriptionPage() {
               </div>
               <div>
                 <FieldLabel text="Mobile" required />
-                <FormInput
-                  placeholder="Enter Mobile Number"
+                <PhoneInputField
                   value={form.mobile}
                   onChange={(v) => setField("mobile", v)}
+                  placeholder="Enter mobile number"
+                  error={errors.mobile}
                 />
-                {errors.mobile && (
-                  <p className="mt-1 text-xs text-red-500">{errors.mobile}</p>
-                )}
               </div>
               <div>
                 <FieldLabel text="Weight (kg)" />

--- a/frontend/src/app/(protected)/doctor/settings/page.tsx
+++ b/frontend/src/app/(protected)/doctor/settings/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { Save, Plus, X, User, Stethoscope, Building2 } from "lucide-react";
 import { useAuthStore, type DoctorChamber } from "@/store/authStore";
+import PhoneInputField, { isValidPhoneNumber } from "@/components/PhoneInputField";
 
 // ── Reusable small components ─────────────────────────────────────────────────
 
@@ -226,7 +227,12 @@ export default function SettingsPage() {
             </Field>
             <Field>
               <FieldLabel text="Mobile Number" />
-              <TextInput value={form.mobileNumber} onChange={(v) => set("mobileNumber", v)} placeholder="+880..." />
+              <PhoneInputField
+                value={form.mobileNumber}
+                onChange={(v) => set("mobileNumber", v)}
+                placeholder="Enter mobile number"
+                error={form.mobileNumber && !isValidPhoneNumber(form.mobileNumber) ? "Enter a valid mobile number." : undefined}
+              />
             </Field>
           </div>
 

--- a/frontend/src/app/doctor-invite/[token]/DoctorInviteAcceptForm.tsx
+++ b/frontend/src/app/doctor-invite/[token]/DoctorInviteAcceptForm.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { X } from "lucide-react";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useAuthStore } from "@/store/authStore";
+import PhoneInputField, { isValidPhoneNumber } from "@/components/PhoneInputField";
 
 const API_BASE_URL = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`;
 
@@ -78,6 +79,10 @@ export default function DoctorInviteAcceptForm({ token }: Props) {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (mobileNumber && !isValidPhoneNumber(mobileNumber)) {
+      toast.error("Enter a valid mobile number.");
+      return;
+    }
     setIsSubmitting(true);
 
     try {
@@ -200,11 +205,12 @@ export default function DoctorInviteAcceptForm({ token }: Props) {
             className="w-full rounded-xl border border-gray-700 bg-gray-900/80 px-4 py-3 text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
           />
 
-          <input
-            placeholder="Mobile Number"
+          <PhoneInputField
+            variant="dark"
             value={mobileNumber}
-            onChange={(e) => setMobileNumber(e.target.value)}
-            className="w-full rounded-xl border border-gray-700 bg-gray-900/80 px-4 py-3 text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+            onChange={setMobileNumber}
+            placeholder="Mobile Number"
+            error={mobileNumber && !isValidPhoneNumber(mobileNumber) ? "Enter a valid mobile number." : undefined}
           />
 
           <input

--- a/frontend/src/components/PhoneInputField.tsx
+++ b/frontend/src/components/PhoneInputField.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import PhoneInput, {
+  getCountries,
+  getCountryCallingCode,
+  isValidPhoneNumber,
+  type Value,
+  type Country,
+} from "react-phone-number-input";
+import en from "react-phone-number-input/locale/en.json";
+import "react-phone-number-input/style.css";
+
+// Country names map from the library locale
+const countryLabels = en as Record<string, string>;
+
+type CountrySelectProps = {
+  value: Country | undefined;
+  onChange: (country: Country | undefined) => void;
+  disabled?: boolean;
+  variant?: "dark" | "default";
+};
+
+function SearchableCountrySelect({
+  value,
+  onChange,
+  disabled,
+  variant = "default",
+}: CountrySelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const isDark = variant === "dark";
+
+  const countries = getCountries().filter((c) => {
+    const name = countryLabels[c] ?? c;
+    return name.toLowerCase().includes(search.toLowerCase());
+  });
+
+  const currentName = value ? (countryLabels[value] ?? value) : "Intl";
+  const currentCode = value ? `+${getCountryCallingCode(value)}` : "";
+
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => searchRef.current?.focus(), 50);
+    } else {
+      setSearch("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const buttonClass = isDark
+    ? "flex items-center gap-1.5 rounded-l-xl border border-r-0 border-gray-700 bg-gray-800 px-3 py-3 text-sm text-white transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 cursor-pointer h-full"
+    : "flex items-center gap-1.5 rounded-l-lg border border-r-0 border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 transition hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none cursor-pointer h-full";
+
+  const dropdownClass = isDark
+    ? "absolute z-50 mt-1 w-64 rounded-xl border border-gray-700 bg-gray-900 shadow-2xl"
+    : "absolute z-50 mt-1 w-64 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-2xl";
+
+  const searchClass = isDark
+    ? "w-full border-b border-gray-700 bg-transparent px-3 py-2 text-sm text-white placeholder-gray-500 outline-none"
+    : "w-full border-b border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 outline-none";
+
+  const optionClass = (selected: boolean) =>
+    isDark
+      ? `flex cursor-pointer items-center gap-2 px-3 py-2 text-sm transition ${selected ? "bg-emerald-500/20 text-emerald-300" : "text-gray-200 hover:bg-gray-800"}`
+      : `flex cursor-pointer items-center gap-2 px-3 py-2 text-sm transition ${selected ? "bg-emerald-50 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300" : "text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"}`;
+
+  return (
+    <div ref={containerRef} className="relative self-stretch">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((o) => !o)}
+        className={buttonClass}
+        aria-label="Select country"
+      >
+        {value ? (
+          <img
+            src={`https://flagcdn.com/w20/${value.toLowerCase()}.png`}
+            alt={currentName}
+            className="h-4 w-6 rounded-sm object-cover"
+          />
+        ) : (
+          <span className="text-base">🌐</span>
+        )}
+        <span className="hidden sm:inline text-xs font-medium">{currentCode}</span>
+        <svg className="h-3 w-3 opacity-50" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className={dropdownClass}>
+          <input
+            ref={searchRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search country..."
+            className={searchClass}
+          />
+          <ul className="max-h-52 overflow-y-auto py-1">
+            {countries.length === 0 && (
+              <li className="px-3 py-2 text-sm text-gray-400">No results</li>
+            )}
+            {countries.map((c) => (
+              <li
+                key={c}
+                className={optionClass(c === value)}
+                onClick={() => {
+                  onChange(c);
+                  setOpen(false);
+                }}
+              >
+                <img
+                  src={`https://flagcdn.com/w20/${c.toLowerCase()}.png`}
+                  alt={countryLabels[c] ?? c}
+                  className="h-4 w-6 rounded-sm object-cover"
+                />
+                <span className="flex-1 truncate">{countryLabels[c] ?? c}</span>
+                <span className="text-xs opacity-50">+{getCountryCallingCode(c)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Exported types ────────────────────────────────────────────────────────────
+
+export { isValidPhoneNumber };
+export type { Value as PhoneValue };
+
+type PhoneInputFieldProps = {
+  value: string;
+  onChange: (value: string) => void;
+  defaultCountry?: Country;
+  placeholder?: string;
+  variant?: "dark" | "default";
+  disabled?: boolean;
+  error?: string;
+};
+
+export default function PhoneInputField({
+  value,
+  onChange,
+  defaultCountry = "BD",
+  placeholder,
+  variant = "default",
+  disabled,
+  error,
+}: PhoneInputFieldProps) {
+  const isDark = variant === "dark";
+
+  const inputClass = isDark
+    ? "flex-1 min-w-0 rounded-r-xl border border-gray-700 bg-gray-900/80 px-3 py-3 text-sm text-white placeholder-gray-500 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+    : "flex-1 min-w-0 rounded-r-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500 transition-colors";
+
+  const containerClass = isDark
+    ? `flex items-stretch${error ? " ring-2 ring-red-500/50 rounded-xl" : ""}`
+    : `flex items-stretch${error ? " ring-2 ring-red-500/50 rounded-lg" : ""}`;
+
+  return (
+    <div className="space-y-1">
+      <div className={containerClass}>
+        <PhoneInput
+          international
+          countryCallingCodeEditable={false}
+          defaultCountry={defaultCountry}
+          value={value as Value}
+          onChange={(v) => onChange(v ?? "")}
+          disabled={disabled}
+          placeholder={placeholder}
+          countrySelectComponent={(props: {
+            value: Country | undefined;
+            onChange: (country: Country | undefined) => void;
+            disabled?: boolean;
+          }) => (
+            <SearchableCountrySelect
+              value={props.value}
+              onChange={props.onChange}
+              disabled={props.disabled}
+              variant={variant}
+            />
+          )}
+          inputComponent={({ ref: _ref, ...inputProps }: React.InputHTMLAttributes<HTMLInputElement> & { ref?: React.Ref<HTMLInputElement> }) => (
+            <input
+              {...inputProps}
+              className={inputClass}
+            />
+          )}
+        />
+      </div>
+      {error && (
+        <p className="text-xs text-red-500">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/admin/AdminTable.tsx
+++ b/frontend/src/components/dashboard/admin/AdminTable.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/pagination";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Check, Plus, ShieldCheck, Trash2, X } from "lucide-react";
+import PhoneInputField, { isValidPhoneNumber } from "@/components/PhoneInputField";
 import {
   Tooltip,
   TooltipContent,
@@ -374,8 +375,8 @@ const AdminTable = ({
       return;
     }
 
-    if (!doctorProfile.mobileNumber) {
-      setDoctorModalError("Mobile number is required.");
+    if (!doctorProfile.mobileNumber || !isValidPhoneNumber(doctorProfile.mobileNumber)) {
+      setDoctorModalError("Enter a valid mobile number.");
       return;
     }
 
@@ -1212,16 +1213,12 @@ const AdminTable = ({
                         <label className="text-sm font-medium text-gray-300">
                           Mobile Number
                         </label>
-                        <input
+                        <PhoneInputField
+                          variant="dark"
                           value={doctorForm.mobileNumber}
-                          onChange={(e) =>
-                            updateDoctorFormField(
-                              "mobileNumber",
-                              e.target.value,
-                            )
-                          }
+                          onChange={(v) => updateDoctorFormField("mobileNumber", v)}
                           placeholder="Enter mobile number"
-                          className="w-full rounded-xl border border-gray-700 bg-gray-900/80 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+                          error={doctorForm.mobileNumber && !isValidPhoneNumber(doctorForm.mobileNumber) ? "Enter a valid mobile number." : undefined}
                         />
                       </div>
 


### PR DESCRIPTION
## Summary

- Adds a reusable `PhoneInputField` component (`react-phone-number-input`) with a custom searchable country dropdown — type a country name to filter, select, and the dial prefix (e.g. `+880`) is locked and non-deletable
- Replaces all four raw mobile number `<input>` fields with this component
- Validates numbers using `isValidPhoneNumber` from `libphonenumber-js` at both the field level (inline error) and on form submit

## Files changed

| File | Change |
|---|---|
| `src/components/PhoneInputField.tsx` | New reusable component (dark + default variants) |
| `doctor/add-prescription/page.tsx` | Patient mobile → PhoneInputField |
| `doctor/settings/page.tsx` | Doctor mobile number → PhoneInputField |
| `components/dashboard/admin/AdminTable.tsx` | Admin doctor form mobile → PhoneInputField (dark variant) |
| `app/doctor-invite/[token]/DoctorInviteAcceptForm.tsx` | Invite form mobile → PhoneInputField (dark variant) |

## Test plan

- [ ] Open add-prescription form — mobile field shows BD flag + `+880` prefix by default, prefix cannot be deleted
- [ ] Click the flag button, type a country name (e.g. "United States") — list filters in real time, selecting it switches the prefix to `+1`
- [ ] Submit with an invalid/incomplete number — inline error "Enter a valid mobile number." appears
- [ ] Submit with a valid number — form proceeds normally
- [ ] Repeat the above in Doctor Settings, Admin doctor modal, and Doctor Invite acceptance form
- [ ] Dark-variant fields (Admin, Invite) render correctly against dark backgrounds

https://claude.ai/code/session_01DW9xFsvUX9JDfNFwNJKKTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DW9xFsvUX9JDfNFwNJKKTw)_