### PR TITLE
feat: medicines browser with search and sort for admin prescriptions page

### DIFF
--- a/backend/controllers/medicine-controller.js
+++ b/backend/controllers/medicine-controller.js
@@ -25,7 +25,7 @@ export const searchMedicines = async (req, res) => {
 };
 
 const ALLOWED_SORT_FIELDS = ["medicine_name", "company_name", "unit_price", "generic_name"];
-const ALLOWED_SEARCH_FIELDS = ["medicine_name", "company_name", "generic_name"];
+const ALLOWED_SEARCH_FIELDS = ["medicine_name", "company_name", "generic_name", "dosage_form"];
 
 export const listMedicines = async (req, res) => {
   try {

--- a/backend/controllers/medicine-controller.js
+++ b/backend/controllers/medicine-controller.js
@@ -23,3 +23,52 @@ export const searchMedicines = async (req, res) => {
     res.status(500).json({ success: false, message: "Server error" });
   }
 };
+
+const ALLOWED_SORT_FIELDS = ["medicine_name", "company_name", "unit_price", "generic_name"];
+const ALLOWED_SEARCH_FIELDS = ["medicine_name", "company_name", "generic_name"];
+
+export const listMedicines = async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 20));
+    const search = String(req.query.search || "").trim();
+    const searchField = ALLOWED_SEARCH_FIELDS.includes(req.query.searchField)
+      ? req.query.searchField
+      : "medicine_name";
+    const sortBy = ALLOWED_SORT_FIELDS.includes(req.query.sortBy)
+      ? req.query.sortBy
+      : "medicine_name";
+    const sortOrder = req.query.sortOrder === "desc" ? -1 : 1;
+
+    const filter = {};
+    if (search.length >= 1) {
+      const escaped = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      filter[searchField] = new RegExp(escaped, "i");
+    }
+
+    const skip = (page - 1) * limit;
+    const [medicines, total] = await Promise.all([
+      Medicine.find(filter)
+        .select("medicine_name generic_name strength dosage_form company_name unit_price")
+        .sort({ [sortBy]: sortOrder })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Medicine.countDocuments(filter),
+    ]);
+
+    res.json({
+      success: true,
+      medicines,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (err) {
+    console.error("listMedicines error:", err);
+    res.status(500).json({ success: false, message: "Server error" });
+  }
+};

--- a/backend/controllers/medicine-controller.js
+++ b/backend/controllers/medicine-controller.js
@@ -13,7 +13,7 @@ export const searchMedicines = async (req, res) => {
     const rx = new RegExp(`^${escaped}`, "i");
 
     const medicines = await Medicine.find({ medicine_name: rx })
-      .select("medicine_name generic_name strength dosage_form company_name unit_price")
+      .select("medicine_name generic_name strength dosage_form unit_type company_name unit_price")
       .limit(10)
       .lean();
 
@@ -49,7 +49,7 @@ export const listMedicines = async (req, res) => {
     const skip = (page - 1) * limit;
     const [medicines, total] = await Promise.all([
       Medicine.find(filter)
-        .select("medicine_name generic_name strength dosage_form company_name unit_price")
+        .select("medicine_name generic_name strength dosage_form unit_type company_name unit_price")
         .sort({ [sortBy]: sortOrder })
         .skip(skip)
         .limit(limit)

--- a/backend/models/medicine.js
+++ b/backend/models/medicine.js
@@ -7,6 +7,7 @@ const medicineSchema = new mongoose.Schema(
     generic_name: { type: String },
     strength: { type: String },
     dosage_form: { type: String },
+    unit_type: { type: String },
     unit_price: { type: Number },
   },
   { collection: "medicines", timestamps: false }

--- a/backend/routes/medicine-routes.js
+++ b/backend/routes/medicine-routes.js
@@ -1,9 +1,11 @@
 import express from "express";
-import { searchMedicines } from "../controllers/medicine-controller.js";
+import { searchMedicines, listMedicines } from "../controllers/medicine-controller.js";
 import { verifyToken } from "../middleware/verifyToken.js";
+import { requireRole } from "../middleware/requireRole.js";
 
 const router = express.Router();
 
 router.get("/search", verifyToken, searchMedicines);
+router.get("/", verifyToken, requireRole("admin", "superadmin"), listMedicines);
 
 export default router;

--- a/frontend/src/app/(protected)/admin/prescriptions/page.tsx
+++ b/frontend/src/app/(protected)/admin/prescriptions/page.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import axios from "axios";
 import SuperAdminGuard from "@/components/auth/SuperAdminGuard";
-import { ChevronDown, ChevronUp, ChevronsUpDown, Search, X } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronsUpDown, Search, X } from "lucide-react";
 
 const API_BASE_URL = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`;
 const api = axios.create({ baseURL: API_BASE_URL, withCredentials: true });
@@ -22,12 +22,13 @@ type Pagination = { page: number; limit: number; total: number; totalPages: numb
 
 type SortField = "medicine_name" | "company_name" | "unit_price" | "generic_name";
 type SortOrder = "asc" | "desc";
-type SearchField = "medicine_name" | "company_name" | "generic_name";
+type SearchField = "medicine_name" | "company_name" | "generic_name" | "dosage_form";
 
 const SEARCH_FIELD_LABELS: Record<SearchField, string> = {
   medicine_name: "Medicine Name",
   company_name: "Company",
   generic_name: "Generic Name",
+  dosage_form: "Form",
 };
 
 const SORT_FIELD_LABELS: Record<SortField, string> = {
@@ -54,10 +55,8 @@ export default function AdminPrescriptionsPage() {
   const [searchField, setSearchField] = useState<SearchField>("medicine_name");
   const [sortBy, setSortBy] = useState<SortField>("medicine_name");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
-  const [fieldDropdownOpen, setFieldDropdownOpen] = useState(false);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const fieldDropdownRef = useRef<HTMLDivElement>(null);
 
   const fetchMedicines = useCallback(async (params: {
     page?: number; search?: string; searchField?: SearchField;
@@ -74,17 +73,6 @@ export default function AdminPrescriptionsPage() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
-
-  // Close dropdown on outside click
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (fieldDropdownRef.current && !fieldDropdownRef.current.contains(e.target as Node)) {
-        setFieldDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
   }, []);
 
   // Initial load
@@ -132,64 +120,55 @@ export default function AdminPrescriptionsPage() {
         </div>
 
         {/* Controls */}
-        <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-4 shadow-xl backdrop-blur-xl">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            {/* Search field selector + input */}
-            <div className="flex flex-1 items-center gap-0 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden">
-              {/* Field selector */}
-              <div ref={fieldDropdownRef} className="relative shrink-0">
-                <button
-                  onClick={() => setFieldDropdownOpen((o) => !o)}
-                  className="flex items-center gap-1.5 px-3 py-2.5 text-sm text-gray-300 border-r border-gray-700 hover:bg-gray-700/50 transition-colors whitespace-nowrap"
-                >
-                  <Search className="h-3.5 w-3.5 text-emerald-400" />
-                  {SEARCH_FIELD_LABELS[searchField]}
-                  <ChevronDown className="h-3 w-3 text-gray-500" />
-                </button>
-                {fieldDropdownOpen && (
-                  <div className="absolute top-full left-0 z-20 mt-1 w-40 rounded-xl border border-gray-700 bg-gray-900 shadow-xl">
-                    {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
-                      <button
-                        key={key}
-                        onClick={() => { setSearchField(key); setFieldDropdownOpen(false); }}
-                        className={`w-full px-3 py-2 text-left text-sm transition-colors hover:bg-gray-800 ${
-                          searchField === key ? "text-emerald-400" : "text-gray-300"
-                        }`}
-                      >
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+        <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-4 shadow-xl backdrop-blur-xl space-y-3">
+          {/* Search input */}
+          <div className="flex items-center gap-0 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden">
+            <Search className="ml-3 h-4 w-4 shrink-0 text-emerald-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={`Search by ${SEARCH_FIELD_LABELS[searchField].toLowerCase()}…`}
+              className="flex-1 bg-transparent px-3 py-2.5 text-sm text-white placeholder-gray-500 outline-none"
+            />
+            {search && (
+              <button
+                onClick={() => setSearch("")}
+                className="mr-2 text-gray-500 hover:text-gray-300"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
 
-              {/* Text input */}
-              <div className="relative flex-1">
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder={`Search by ${SEARCH_FIELD_LABELS[searchField].toLowerCase()}…`}
-                  className="w-full bg-transparent px-3 py-2.5 text-sm text-white placeholder-gray-500 outline-none"
-                />
-                {search && (
-                  <button
-                    onClick={() => setSearch("")}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </div>
+          {/* Search field pills + sort buttons */}
+          <div className="flex flex-wrap items-center justify-between gap-y-2 gap-x-3">
+            {/* Search field pills */}
+            <div className="flex flex-wrap gap-1.5">
+              <span className="self-center text-xs text-gray-500 mr-1">Search in:</span>
+              {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => setSearchField(key)}
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                    searchField === key
+                      ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
+                      : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
 
             {/* Sort buttons */}
-            <div className="flex flex-wrap gap-2 shrink-0">
+            <div className="flex flex-wrap gap-1.5">
+              <span className="self-center text-xs text-gray-500 mr-1">Sort by:</span>
               {(Object.entries(SORT_FIELD_LABELS) as [SortField, string][]).map(([field, label]) => (
                 <button
                   key={field}
                   onClick={() => handleSort(field)}
-                  className={`flex items-center gap-1 rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
+                  className={`flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
                     sortBy === field
                       ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
                       : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"

--- a/frontend/src/app/(protected)/admin/prescriptions/page.tsx
+++ b/frontend/src/app/(protected)/admin/prescriptions/page.tsx
@@ -55,8 +55,10 @@ export default function AdminPrescriptionsPage() {
   const [searchField, setSearchField] = useState<SearchField>("medicine_name");
   const [sortBy, setSortBy] = useState<SortField>("medicine_name");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+  const [fieldDropdownOpen, setFieldDropdownOpen] = useState(false);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fieldDropdownRef = useRef<HTMLDivElement>(null);
 
   const fetchMedicines = useCallback(async (params: {
     page?: number; search?: string; searchField?: SearchField;
@@ -73,6 +75,17 @@ export default function AdminPrescriptionsPage() {
     } finally {
       setIsLoading(false);
     }
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (fieldDropdownRef.current && !fieldDropdownRef.current.contains(e.target as Node)) {
+        setFieldDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
   }, []);
 
   // Initial load
@@ -121,54 +134,61 @@ export default function AdminPrescriptionsPage() {
 
         {/* Controls */}
         <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-4 shadow-xl backdrop-blur-xl space-y-3">
-          {/* Search input */}
-          <div className="flex items-center gap-0 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden">
-            <Search className="ml-3 h-4 w-4 shrink-0 text-emerald-400" />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={`Search by ${SEARCH_FIELD_LABELS[searchField].toLowerCase()}…`}
-              className="flex-1 bg-transparent px-3 py-2.5 text-sm text-white placeholder-gray-500 outline-none"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch("")}
-                className="mr-2 text-gray-500 hover:text-gray-300"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </div>
-
-          {/* Search field pills + sort buttons */}
-          <div className="flex flex-wrap items-center justify-between gap-y-2 gap-x-3">
-            {/* Search field pills */}
-            <div className="flex flex-wrap gap-1.5">
-              <span className="self-center text-xs text-gray-500 mr-1">Search in:</span>
-              {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
+          {/* Row 1: search bar + sort buttons */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            {/* Field dropdown + search input */}
+            <div className="flex flex-1 items-center gap-0 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden">
+              <div ref={fieldDropdownRef} className="relative shrink-0">
                 <button
-                  key={key}
-                  onClick={() => setSearchField(key)}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                    searchField === key
-                      ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
-                      : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"
-                  }`}
+                  onClick={() => setFieldDropdownOpen((o) => !o)}
+                  className="flex items-center gap-1.5 px-3 py-2.5 text-sm text-gray-300 border-r border-gray-700 hover:bg-gray-700/50 transition-colors whitespace-nowrap"
                 >
-                  {label}
+                  <Search className="h-3.5 w-3.5 text-emerald-400" />
+                  {SEARCH_FIELD_LABELS[searchField]}
+                  <ChevronDown className="h-3 w-3 text-gray-500" />
                 </button>
-              ))}
+                {fieldDropdownOpen && (
+                  <div className="absolute top-full left-0 z-20 mt-1 w-40 rounded-xl border border-gray-700 bg-gray-900 shadow-xl">
+                    {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
+                      <button
+                        key={key}
+                        onClick={() => { setSearchField(key); setFieldDropdownOpen(false); }}
+                        className={`w-full px-3 py-2 text-left text-sm transition-colors hover:bg-gray-800 ${
+                          searchField === key ? "text-emerald-400" : "text-gray-300"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="relative flex-1">
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={`Search by ${SEARCH_FIELD_LABELS[searchField].toLowerCase()}…`}
+                  className="w-full bg-transparent px-3 py-2.5 text-sm text-white placeholder-gray-500 outline-none"
+                />
+                {search && (
+                  <button
+                    onClick={() => setSearch("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Sort buttons */}
-            <div className="flex flex-wrap gap-1.5">
-              <span className="self-center text-xs text-gray-500 mr-1">Sort by:</span>
+            <div className="flex flex-wrap gap-2 shrink-0">
               {(Object.entries(SORT_FIELD_LABELS) as [SortField, string][]).map(([field, label]) => (
                 <button
                   key={field}
                   onClick={() => handleSort(field)}
-                  className={`flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  className={`flex items-center gap-1 rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
                     sortBy === field
                       ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
                       : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"
@@ -179,6 +199,24 @@ export default function AdminPrescriptionsPage() {
                 </button>
               ))}
             </div>
+          </div>
+
+          {/* Row 2: search field pills */}
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-gray-500">Search in:</span>
+            {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
+              <button
+                key={key}
+                onClick={() => { setSearchField(key); setFieldDropdownOpen(false); }}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  searchField === key
+                    ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
+                    : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
         </div>
 

--- a/frontend/src/app/(protected)/admin/prescriptions/page.tsx
+++ b/frontend/src/app/(protected)/admin/prescriptions/page.tsx
@@ -14,6 +14,7 @@ type Medicine = {
   generic_name?: string;
   strength?: string;
   dosage_form?: string;
+  unit_type?: string;
   company_name?: string;
   unit_price?: number;
 };
@@ -260,6 +261,7 @@ export default function AdminPrescriptionsPage() {
                   </th>
                   <th className="px-4 py-3">Strength</th>
                   <th className="px-4 py-3">Form</th>
+                  <th className="px-4 py-3">Unit Type</th>
                   <th
                     className="px-4 py-3 cursor-pointer hover:text-gray-300 transition-colors"
                     onClick={() => handleSort("company_name")}
@@ -278,7 +280,7 @@ export default function AdminPrescriptionsPage() {
                 {isLoading
                   ? Array.from({ length: 8 }).map((_, i) => (
                       <tr key={i} className="border-b border-gray-800/50 animate-pulse">
-                        {Array.from({ length: 6 }).map((_, j) => (
+                        {Array.from({ length: 7 }).map((_, j) => (
                           <td key={j} className="px-4 py-3">
                             <div className="h-3 rounded bg-gray-800" style={{ width: `${60 + Math.random() * 30}%` }} />
                           </td>
@@ -288,7 +290,7 @@ export default function AdminPrescriptionsPage() {
                   : medicines.length === 0
                   ? (
                       <tr>
-                        <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                        <td colSpan={7} className="px-4 py-12 text-center text-gray-500">
                           No medicines found.
                         </td>
                       </tr>
@@ -308,6 +310,7 @@ export default function AdminPrescriptionsPage() {
                             </span>
                           ) : "—"}
                         </td>
+                        <td className="px-4 py-3 text-gray-400">{med.unit_type || "—"}</td>
                         <td className="px-4 py-3 text-gray-400">{med.company_name || "—"}</td>
                         <td className="px-4 py-3 text-right">
                           {med.unit_price != null ? (

--- a/frontend/src/app/(protected)/admin/prescriptions/page.tsx
+++ b/frontend/src/app/(protected)/admin/prescriptions/page.tsx
@@ -1,15 +1,350 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import axios from "axios";
 import SuperAdminGuard from "@/components/auth/SuperAdminGuard";
+import { ChevronDown, ChevronUp, ChevronsUpDown, Search, X } from "lucide-react";
+
+const API_BASE_URL = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`;
+const api = axios.create({ baseURL: API_BASE_URL, withCredentials: true });
+
+type Medicine = {
+  _id: string;
+  medicine_name: string;
+  generic_name?: string;
+  strength?: string;
+  dosage_form?: string;
+  company_name?: string;
+  unit_price?: number;
+};
+
+type Pagination = { page: number; limit: number; total: number; totalPages: number };
+
+type SortField = "medicine_name" | "company_name" | "unit_price" | "generic_name";
+type SortOrder = "asc" | "desc";
+type SearchField = "medicine_name" | "company_name" | "generic_name";
+
+const SEARCH_FIELD_LABELS: Record<SearchField, string> = {
+  medicine_name: "Medicine Name",
+  company_name: "Company",
+  generic_name: "Generic Name",
+};
+
+const SORT_FIELD_LABELS: Record<SortField, string> = {
+  medicine_name: "Medicine Name",
+  company_name: "Company",
+  unit_price: "Price",
+  generic_name: "Generic Name",
+};
+
+function SortIcon({ field, active, order }: { field: SortField; active: SortField; order: SortOrder }) {
+  if (field !== active) return <ChevronsUpDown className="inline-block ml-1 h-3.5 w-3.5 text-gray-500" />;
+  return order === "asc"
+    ? <ChevronUp className="inline-block ml-1 h-3.5 w-3.5 text-emerald-400" />
+    : <ChevronDown className="inline-block ml-1 h-3.5 w-3.5 text-emerald-400" />;
+}
+
 export default function AdminPrescriptionsPage() {
+  const [medicines, setMedicines] = useState<Medicine[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 20, total: 0, totalPages: 1 });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [searchField, setSearchField] = useState<SearchField>("medicine_name");
+  const [sortBy, setSortBy] = useState<SortField>("medicine_name");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+  const [fieldDropdownOpen, setFieldDropdownOpen] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fieldDropdownRef = useRef<HTMLDivElement>(null);
+
+  const fetchMedicines = useCallback(async (params: {
+    page?: number; search?: string; searchField?: SearchField;
+    sortBy?: SortField; sortOrder?: SortOrder;
+  }) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await api.get("/medicines", { params: { limit: 20, ...params } });
+      setMedicines(res.data.medicines);
+      setPagination(res.data.pagination);
+    } catch {
+      setError("Failed to load medicines.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (fieldDropdownRef.current && !fieldDropdownRef.current.contains(e.target as Node)) {
+        setFieldDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    void fetchMedicines({ page: 1, search: "", searchField: "medicine_name", sortBy: "medicine_name", sortOrder: "asc" });
+  }, [fetchMedicines]);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void fetchMedicines({ page: 1, search, searchField, sortBy, sortOrder });
+    }, 300);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [search, searchField, sortBy, sortOrder, fetchMedicines]);
+
+  const handleSort = (field: SortField) => {
+    if (field === sortBy) {
+      setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(field);
+      setSortOrder("asc");
+    }
+  };
+
+  const handlePage = (newPage: number) => {
+    void fetchMedicines({ page: newPage, search, searchField, sortBy, sortOrder });
+  };
+
   return (
     <SuperAdminGuard>
-      <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl backdrop-blur-xl text-white">
-        <h2 className="text-3xl font-bold bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-transparent">
-          Prescriptions
-        </h2>
-        <p className="mt-2 text-sm text-gray-400">
-          This page will show prescription records once that feature is built.
-        </p>
-      </div>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="space-y-6"
+      >
+        {/* Header */}
+        <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl backdrop-blur-xl">
+          <h2 className="bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-3xl font-bold text-transparent">
+            Medicines
+          </h2>
+          <p className="mt-1 text-sm text-gray-400">
+            Browse, search, and sort the medicine database.
+          </p>
+        </div>
+
+        {/* Controls */}
+        <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-4 shadow-xl backdrop-blur-xl">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            {/* Search field selector + input */}
+            <div className="flex flex-1 items-center gap-0 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden">
+              {/* Field selector */}
+              <div ref={fieldDropdownRef} className="relative shrink-0">
+                <button
+                  onClick={() => setFieldDropdownOpen((o) => !o)}
+                  className="flex items-center gap-1.5 px-3 py-2.5 text-sm text-gray-300 border-r border-gray-700 hover:bg-gray-700/50 transition-colors whitespace-nowrap"
+                >
+                  <Search className="h-3.5 w-3.5 text-emerald-400" />
+                  {SEARCH_FIELD_LABELS[searchField]}
+                  <ChevronDown className="h-3 w-3 text-gray-500" />
+                </button>
+                {fieldDropdownOpen && (
+                  <div className="absolute top-full left-0 z-20 mt-1 w-40 rounded-xl border border-gray-700 bg-gray-900 shadow-xl">
+                    {(Object.entries(SEARCH_FIELD_LABELS) as [SearchField, string][]).map(([key, label]) => (
+                      <button
+                        key={key}
+                        onClick={() => { setSearchField(key); setFieldDropdownOpen(false); }}
+                        className={`w-full px-3 py-2 text-left text-sm transition-colors hover:bg-gray-800 ${
+                          searchField === key ? "text-emerald-400" : "text-gray-300"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Text input */}
+              <div className="relative flex-1">
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={`Search by ${SEARCH_FIELD_LABELS[searchField].toLowerCase()}…`}
+                  className="w-full bg-transparent px-3 py-2.5 text-sm text-white placeholder-gray-500 outline-none"
+                />
+                {search && (
+                  <button
+                    onClick={() => setSearch("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Sort buttons */}
+            <div className="flex flex-wrap gap-2 shrink-0">
+              {(Object.entries(SORT_FIELD_LABELS) as [SortField, string][]).map(([field, label]) => (
+                <button
+                  key={field}
+                  onClick={() => handleSort(field)}
+                  className={`flex items-center gap-1 rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
+                    sortBy === field
+                      ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
+                      : "bg-gray-800 text-gray-400 border border-gray-700 hover:bg-gray-700"
+                  }`}
+                >
+                  {label}
+                  <SortIcon field={field} active={sortBy} order={sortOrder} />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="rounded-3xl border border-gray-800 bg-gray-900/70 shadow-xl backdrop-blur-xl overflow-hidden">
+          {error && (
+            <div className="px-6 py-4 text-sm text-red-400">{error}</div>
+          )}
+
+          {/* Count */}
+          {!error && (
+            <div className="px-6 py-3 border-b border-gray-800 flex items-center justify-between">
+              <span className="text-xs text-gray-400">
+                {isLoading
+                  ? "Loading…"
+                  : `${pagination.total.toLocaleString()} medicine${pagination.total !== 1 ? "s" : ""} found`}
+              </span>
+              {pagination.totalPages > 1 && (
+                <span className="text-xs text-gray-500">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-800 text-left text-xs text-gray-500 uppercase tracking-wide">
+                  <th
+                    className="px-4 py-3 cursor-pointer hover:text-gray-300 transition-colors"
+                    onClick={() => handleSort("medicine_name")}
+                  >
+                    Medicine Name <SortIcon field="medicine_name" active={sortBy} order={sortOrder} />
+                  </th>
+                  <th
+                    className="px-4 py-3 cursor-pointer hover:text-gray-300 transition-colors"
+                    onClick={() => handleSort("generic_name")}
+                  >
+                    Generic Name <SortIcon field="generic_name" active={sortBy} order={sortOrder} />
+                  </th>
+                  <th className="px-4 py-3">Strength</th>
+                  <th className="px-4 py-3">Form</th>
+                  <th
+                    className="px-4 py-3 cursor-pointer hover:text-gray-300 transition-colors"
+                    onClick={() => handleSort("company_name")}
+                  >
+                    Company <SortIcon field="company_name" active={sortBy} order={sortOrder} />
+                  </th>
+                  <th
+                    className="px-4 py-3 text-right cursor-pointer hover:text-gray-300 transition-colors"
+                    onClick={() => handleSort("unit_price")}
+                  >
+                    Price <SortIcon field="unit_price" active={sortBy} order={sortOrder} />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading
+                  ? Array.from({ length: 8 }).map((_, i) => (
+                      <tr key={i} className="border-b border-gray-800/50 animate-pulse">
+                        {Array.from({ length: 6 }).map((_, j) => (
+                          <td key={j} className="px-4 py-3">
+                            <div className="h-3 rounded bg-gray-800" style={{ width: `${60 + Math.random() * 30}%` }} />
+                          </td>
+                        ))}
+                      </tr>
+                    ))
+                  : medicines.length === 0
+                  ? (
+                      <tr>
+                        <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                          No medicines found.
+                        </td>
+                      </tr>
+                    )
+                  : medicines.map((med) => (
+                      <tr
+                        key={med._id}
+                        className="border-b border-gray-800/40 hover:bg-gray-800/30 transition-colors"
+                      >
+                        <td className="px-4 py-3 font-medium text-white">{med.medicine_name || "—"}</td>
+                        <td className="px-4 py-3 text-gray-400">{med.generic_name || "—"}</td>
+                        <td className="px-4 py-3 text-gray-400">{med.strength || "—"}</td>
+                        <td className="px-4 py-3">
+                          {med.dosage_form ? (
+                            <span className="inline-block rounded-md bg-gray-800 px-2 py-0.5 text-xs text-gray-300">
+                              {med.dosage_form}
+                            </span>
+                          ) : "—"}
+                        </td>
+                        <td className="px-4 py-3 text-gray-400">{med.company_name || "—"}</td>
+                        <td className="px-4 py-3 text-right">
+                          {med.unit_price != null ? (
+                            <span className="text-emerald-400 font-medium">৳{med.unit_price.toFixed(2)}</span>
+                          ) : "—"}
+                        </td>
+                      </tr>
+                    ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {pagination.totalPages > 1 && !isLoading && (
+            <div className="flex items-center justify-center gap-2 px-6 py-4 border-t border-gray-800">
+              <button
+                onClick={() => handlePage(pagination.page - 1)}
+                disabled={pagination.page <= 1}
+                className="rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-xs text-gray-300 disabled:opacity-40 hover:bg-gray-700 transition-colors"
+              >
+                Previous
+              </button>
+
+              {Array.from({ length: Math.min(7, pagination.totalPages) }, (_, i) => {
+                const half = 3;
+                let start = Math.max(1, pagination.page - half);
+                const end = Math.min(pagination.totalPages, start + 6);
+                start = Math.max(1, end - 6);
+                return start + i;
+              }).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => handlePage(p)}
+                  className={`rounded-lg px-3 py-1.5 text-xs transition-colors ${
+                    p === pagination.page
+                      ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/40"
+                      : "border border-gray-700 bg-gray-800 text-gray-400 hover:bg-gray-700"
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+
+              <button
+                onClick={() => handlePage(pagination.page + 1)}
+                disabled={pagination.page >= pagination.totalPages}
+                className="rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-xs text-gray-300 disabled:opacity-40 hover:bg-gray-700 transition-colors"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+      </motion.div>
     </SuperAdminGuard>
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Backend**: Added `GET /api/medicines` endpoint (admin/superadmin only) supporting pagination, search by field, and multi-field sorting
- **Frontend**: Replaced the placeholder admin prescriptions page with a full medicines browser table

## Features

### Search
- Combined search field selector + text input in one control
- Searchable fields: **Medicine Name** (default), **Company**, **Generic Name**
- 300ms debounce — results update as you type
- Clear button (×) to reset search

### Sort
- Quick-sort buttons for: Medicine Name, Company, Price, Generic Name
- Clickable column headers also toggle sort
- Active sort shows ▲/▼ arrow; inactive columns show ⇅
- Toggles asc/desc on repeat click

### Table
- Columns: Medicine Name, Generic Name, Strength, Dosage Form, Company, Price (৳)
- Skeleton loading rows while fetching
- Paginated (20 per page) with page navigation
- Total count displayed in header

## Test plan

- [ ] Search by medicine name — results filter correctly
- [ ] Switch search field to Company, search — results match company field
- [ ] Switch search field to Generic Name — results match generic name
- [ ] Click sort buttons — table reorders; arrow direction flips on second click
- [ ] Click column headers — same sort behaviour
- [ ] Navigate pages — page counter updates, results change
- [ ] Non-admin role should receive 403 from the API

https://claude.ai/code/session_01GTQkxRN3gYW4qpRU2oC1jn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTQkxRN3gYW4qpRU2oC1jn)_