### PR TITLE
Show unit type and price in Rx medicine search dropdown preview

### DIFF
--- a/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
+++ b/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
@@ -69,6 +69,7 @@ type MedicineResult = {
   strength?: string;
   dosage_form?: string;
   company_name?: string;
+  unit_type?: string;
   unit_price?: number;
 };
 
@@ -470,6 +471,11 @@ function MedicineSearchInput({
                 {(m.generic_name || m.strength) && (
                   <p className="text-xs text-gray-500 dark:text-gray-400">
                     {[m.generic_name, m.strength].filter(Boolean).join(" · ")}
+                  </p>
+                )}
+                {(m.unit_type || m.unit_price != null) && (
+                  <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                    {[m.unit_type, m.unit_price != null ? `৳${m.unit_price}` : null].filter(Boolean).join(" · ")}
                   </p>
                 )}
               </button>


### PR DESCRIPTION
## Summary

- Added `unit_type` field to the `MedicineResult` type
- Dropdown suggestion items now display a third line with **unit type** and **price** (styled in emerald green) beneath the existing generic name / strength line
- Price is formatted as `৳{unit_price}` and unit type is shown as-is; both are joined with ` · ` when present

## Test plan

- [ ] Search for a medicine in the Rx add-prescription page
- [ ] Verify the dropdown shows: medicine name (bold), generic name · strength, unit type · ৳price
- [ ] Confirm items with missing unit_type or unit_price gracefully omit that portion
- [ ] Confirm the selected medicine info card below still shows all fields correctly

https://claude.ai/code/session_01Ny34KZetpFTGm1c2b2tTjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ny34KZetpFTGm1c2b2tTjn)_