### PR TITLE
Fix mobile sidebar button not revealing sidebar

### DIFF
--- a/frontend/src/app/(protected)/admin/layout.tsx
+++ b/frontend/src/app/(protected)/admin/layout.tsx
@@ -9,19 +9,31 @@ export default function AdminDashboardLayout({
   children: React.ReactNode;
 }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleToggle = () => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      setMobileOpen((prev) => !prev);
+    } else {
+      setCollapsed((prev) => !prev);
+    }
+  };
+
   return (
     <AdminGuard>
       <div className="flex h-screen w-full overflow-hidden text-white">
         <AdminSidebar
           collapsed={collapsed}
           onToggle={() => setCollapsed((prev) => !prev)}
+          mobileOpen={mobileOpen}
+          onMobileClose={() => setMobileOpen(false)}
         />
 
         <div className="flex h-screen min-w-0 flex-1 flex-col overflow-hidden">
           <div className="shrink-0">
             <AdminTopNav
               collapsed={collapsed}
-              onToggle={() => setCollapsed((prev) => !prev)}
+              onToggle={handleToggle}
             />
           </div>
 

--- a/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
+++ b/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
@@ -1558,34 +1558,46 @@ export default function AddPrescriptionPage() {
                   key={i}
                   className="rounded-xl bg-gray-50 dark:bg-gray-800/50 p-3 space-y-2"
                 >
-                  {/* Mobile layout: stacked; Desktop: grid */}
+                  {/* Mobile layout: stacked with labels; Desktop: grid */}
                   <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[2fr_1fr_130px_1.2fr_auto] sm:items-start">
-                    <MedicineSearchInput
-                      value={med.medicine}
-                      onChange={(v) => setMed(i, "medicine", v)}
-                      selectedMed={selectedMedicines[i] ?? null}
-                      onSelect={(m) => setSelectedMed(i, m)}
-                      searchBy={medicineSearchBy}
-                    />
-                    <FormInput
-                      type="number"
-                      placeholder="Days e.g. 7"
-                      min="1"
-                      step="1"
-                      value={med.days}
-                      onChange={(v) =>
-                        setMed(i, "days", v.replace(/[^0-9]/g, ""))
-                      }
-                    />
-                    <TimesPerDayInput
-                      value={med.timesPerDay}
-                      onChange={(v) => setMed(i, "timesPerDay", v)}
-                    />
-                    <FormSelect
-                      value={med.timing}
-                      onChange={(v) => setMed(i, "timing", v)}
-                      options={TIMING_OPTIONS}
-                    />
+                    <div className="sm:contents">
+                      <p className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:hidden">Medicine</p>
+                      <MedicineSearchInput
+                        value={med.medicine}
+                        onChange={(v) => setMed(i, "medicine", v)}
+                        selectedMed={selectedMedicines[i] ?? null}
+                        onSelect={(m) => setSelectedMed(i, m)}
+                        searchBy={medicineSearchBy}
+                      />
+                    </div>
+                    <div className="sm:contents">
+                      <p className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:hidden">Days</p>
+                      <FormInput
+                        type="number"
+                        placeholder="Days e.g. 7"
+                        min="1"
+                        step="1"
+                        value={med.days}
+                        onChange={(v) =>
+                          setMed(i, "days", v.replace(/[^0-9]/g, ""))
+                        }
+                      />
+                    </div>
+                    <div className="sm:contents">
+                      <p className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:hidden">Times/Day</p>
+                      <TimesPerDayInput
+                        value={med.timesPerDay}
+                        onChange={(v) => setMed(i, "timesPerDay", v)}
+                      />
+                    </div>
+                    <div className="sm:contents">
+                      <p className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:hidden">Timing</p>
+                      <FormSelect
+                        value={med.timing}
+                        onChange={(v) => setMed(i, "timing", v)}
+                        options={TIMING_OPTIONS}
+                      />
+                    </div>
                     <div className="flex justify-end sm:justify-center sm:pt-2">
                       <RemoveBtn onClick={() => removeMed(i)} />
                     </div>
@@ -1663,7 +1675,7 @@ export default function AddPrescriptionPage() {
               type="button"
               onClick={() => void handleSubmit()}
               disabled={isSaving}
-              className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-green-500 to-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow hover:opacity-90 active:scale-95 transition-all disabled:opacity-60 cursor-pointer"
+              className="flex-1 sm:flex-none inline-flex justify-center items-center gap-2 rounded-xl bg-gradient-to-r from-green-500 to-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow hover:opacity-90 active:scale-95 transition-all disabled:opacity-60 cursor-pointer"
             >
               <Save className="h-4 w-4" />
               {isSaving ? "Saving…" : editId ? "Update" : "Save"}
@@ -1672,7 +1684,7 @@ export default function AddPrescriptionPage() {
             <button
               type="button"
               onClick={handleClear}
-              className="inline-flex items-center gap-2 rounded-xl border border-red-200 dark:border-red-800/50 bg-white dark:bg-gray-800 px-5 py-2.5 text-sm font-semibold text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 active:scale-95 transition-all cursor-pointer"
+              className="flex-1 sm:flex-none inline-flex justify-center items-center gap-2 rounded-xl border border-red-200 dark:border-red-800/50 bg-white dark:bg-gray-800 px-5 py-2.5 text-sm font-semibold text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 active:scale-95 transition-all cursor-pointer"
             >
               <Trash2 className="h-4 w-4" />
               Clear Form
@@ -1681,7 +1693,7 @@ export default function AddPrescriptionPage() {
             <button
               type="button"
               onClick={() => void handleDownloadPdf()}
-              className="ml-auto inline-flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:border-gray-400 active:scale-95 transition-all cursor-pointer"
+              className="w-full sm:w-auto sm:ml-auto inline-flex justify-center items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:border-gray-400 active:scale-95 transition-all cursor-pointer"
             >
               <Download className="h-4 w-4" />
               Download PDF

--- a/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
+++ b/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
@@ -1561,7 +1561,7 @@ export default function AddPrescriptionPage() {
                   {/* Mobile layout: stacked with labels; Desktop: grid */}
                   <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[2fr_1fr_130px_1.2fr_auto] sm:items-start">
                     <div className="sm:contents">
-                      <div className="flex items-center justify-between sm:hidden">
+                      <div className="flex items-center justify-between sm:hidden mb-2">
                         <span className="text-xs font-medium text-gray-400 dark:text-gray-500">Medicine</span>
                         <div className="flex overflow-hidden rounded-md border border-gray-200 dark:border-gray-700 text-xs">
                           <button

--- a/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
+++ b/frontend/src/app/(protected)/doctor/add-prescription/page.tsx
@@ -364,9 +364,9 @@ function TimesPerDayInput({
   };
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-2 w-full">
       {slots.map((slot, idx) => (
-        <span key={idx} className="flex items-center gap-1">
+        <span key={idx} className="contents">
           <input
             ref={refs[idx]}
             type="text"
@@ -379,10 +379,10 @@ function TimesPerDayInput({
               if (v === "0" || v === "1" || v === "") update(idx, v);
             }}
             onKeyDown={(e) => handleKey(idx, e)}
-            className="w-8 text-center rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500 transition-colors"
+            className="flex-1 min-w-0 text-center rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500 transition-colors"
           />
           {idx < 2 && (
-            <span className="text-gray-400 font-bold text-xs select-none">
+            <span className="text-gray-400 font-bold text-xs select-none shrink-0">
               +
             </span>
           )}
@@ -1561,7 +1561,33 @@ export default function AddPrescriptionPage() {
                   {/* Mobile layout: stacked with labels; Desktop: grid */}
                   <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[2fr_1fr_130px_1.2fr_auto] sm:items-start">
                     <div className="sm:contents">
-                      <p className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:hidden">Medicine</p>
+                      <div className="flex items-center justify-between sm:hidden">
+                        <span className="text-xs font-medium text-gray-400 dark:text-gray-500">Medicine</span>
+                        <div className="flex overflow-hidden rounded-md border border-gray-200 dark:border-gray-700 text-xs">
+                          <button
+                            type="button"
+                            onClick={() => setMedicineSearchBy("brand")}
+                            className={`px-2.5 py-0.5 font-medium transition-colors cursor-pointer ${
+                              medicineSearchBy === "brand"
+                                ? "bg-emerald-500 text-white"
+                                : "bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
+                            }`}
+                          >
+                            Brand
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setMedicineSearchBy("generic")}
+                            className={`px-2.5 py-0.5 font-medium transition-colors border-l border-gray-200 dark:border-gray-700 cursor-pointer ${
+                              medicineSearchBy === "generic"
+                                ? "bg-emerald-500 text-white"
+                                : "bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
+                            }`}
+                          >
+                            Generic
+                          </button>
+                        </div>
+                      </div>
                       <MedicineSearchInput
                         value={med.medicine}
                         onChange={(v) => setMed(i, "medicine", v)}

--- a/frontend/src/app/(protected)/doctor/layout.tsx
+++ b/frontend/src/app/(protected)/doctor/layout.tsx
@@ -12,6 +12,15 @@ export default function DoctorDashboardLayout({
   children: React.ReactNode;
 }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleToggle = () => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      setMobileOpen((prev) => !prev);
+    } else {
+      setCollapsed((prev) => !prev);
+    }
+  };
 
   return (
     <DoctorGuard>
@@ -20,13 +29,15 @@ export default function DoctorDashboardLayout({
           <DoctorSidebar
             collapsed={collapsed}
             onToggle={() => setCollapsed((prev) => !prev)}
+            mobileOpen={mobileOpen}
+            onMobileClose={() => setMobileOpen(false)}
           />
 
           <div className="flex h-screen min-w-0 flex-1 flex-col overflow-hidden">
             <div className="shrink-0">
               <DoctorTopNav
                 collapsed={collapsed}
-                onToggle={() => setCollapsed((prev) => !prev)}
+                onToggle={handleToggle}
               />
             </div>
 

--- a/frontend/src/components/dashboard/admin/AdminSidebar.tsx
+++ b/frontend/src/components/dashboard/admin/AdminSidebar.tsx
@@ -16,6 +16,8 @@ import {
 type Props = {
   collapsed: boolean;
   onToggle: () => void;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
 };
 
 const navItems: {
@@ -56,7 +58,7 @@ const navItems: {
   },
 ];
 
-export default function AdminSidebar({ collapsed, onToggle }: Props) {
+export default function AdminSidebar({ collapsed, onToggle, mobileOpen, onMobileClose }: Props) {
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
 
@@ -73,10 +75,23 @@ export default function AdminSidebar({ collapsed, onToggle }: Props) {
       : "Full system control and user management.";
 
   return (
+    <>
+      {/* Mobile backdrop */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={onMobileClose}
+          aria-hidden="true"
+        />
+      )}
     <aside
       className={[
-        "hidden md:flex h-screen shrink-0 border-r border-gray-800 bg-gray-950/70 backdrop-blur-xl transition-all duration-300",
-        collapsed ? "w-24" : "w-72",
+        "fixed inset-y-0 left-0 z-50 flex h-screen shrink-0 border-r border-gray-800 bg-gray-950/70 backdrop-blur-xl transition-all duration-300",
+        // Mobile: slide in/out via transform; desktop: static position, always visible
+        "md:relative md:z-auto md:translate-x-0",
+        mobileOpen ? "translate-x-0" : "-translate-x-full",
+        // Width: mobile always full, desktop based on collapsed
+        collapsed ? "w-72 md:w-24" : "w-72",
       ].join(" ")}
     >
       <div className="flex h-full w-full flex-col px-4 py-6">
@@ -158,5 +173,6 @@ export default function AdminSidebar({ collapsed, onToggle }: Props) {
         </div>
       </div>
     </aside>
+    </>
   );
 }

--- a/frontend/src/components/dashboard/doctor/DoctorSidebar.tsx
+++ b/frontend/src/components/dashboard/doctor/DoctorSidebar.tsx
@@ -17,6 +17,8 @@ import {
 type Props = {
   collapsed: boolean;
   onToggle: () => void;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
 };
 
 const navItems = [
@@ -28,16 +30,29 @@ const navItems = [
   { label: "Settings", href: "/doctor/settings", icon: Settings, sub: false },
 ];
 
-export default function DoctorSidebar({ collapsed, onToggle }: Props) {
+export default function DoctorSidebar({ collapsed, onToggle, mobileOpen, onMobileClose }: Props) {
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
 
   return (
+    <>
+      {/* Mobile backdrop */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={onMobileClose}
+          aria-hidden="true"
+        />
+      )}
     <aside
       className={[
-        "hidden md:flex h-screen shrink-0 border-r border-gray-200 dark:border-gray-800",
+        "fixed inset-y-0 left-0 z-50 flex h-screen shrink-0 border-r border-gray-200 dark:border-gray-800",
         "bg-white dark:bg-gray-950/70 backdrop-blur-xl transition-all duration-300",
-        collapsed ? "w-20" : "w-72",
+        // Mobile: slide in/out via transform; desktop: static position, always visible
+        "md:relative md:z-auto md:translate-x-0",
+        mobileOpen ? "translate-x-0" : "-translate-x-full",
+        // Width: mobile always full, desktop based on collapsed
+        collapsed ? "w-72 md:w-20" : "w-72",
       ].join(" ")}
     >
       <div className="flex h-full w-full flex-col px-3 py-6">
@@ -129,5 +144,6 @@ export default function DoctorSidebar({ collapsed, onToggle }: Props) {
         </div>
       </div>
     </aside>
+    </>
   );
 }

--- a/frontend/src/components/dashboard/doctor/DoctorSidebar.tsx
+++ b/frontend/src/components/dashboard/doctor/DoctorSidebar.tsx
@@ -91,6 +91,7 @@ export default function DoctorSidebar({ collapsed, onToggle, mobileOpen, onMobil
                 key={item.href}
                 href={item.href}
                 title={collapsed ? item.label : undefined}
+                onClick={onMobileClose}
                 className={[
                   "group flex items-center rounded-2xl text-sm font-medium transition-all duration-200",
                   collapsed ? "justify-center px-3 py-3" : "gap-3 px-4 py-2.5",

--- a/frontend/src/components/dashboard/doctor/DoctorTopNav.tsx
+++ b/frontend/src/components/dashboard/doctor/DoctorTopNav.tsx
@@ -45,7 +45,7 @@ export default function DoctorTopNav({ onToggle }: Props) {
             <Menu className="h-5 w-5 text-emerald-500" />
           </button>
 
-          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-emerald-500/20 bg-emerald-500/10">
+          <div className="hidden lg:flex h-10 w-10 items-center justify-center rounded-2xl border border-emerald-500/20 bg-emerald-500/10">
             <Stethoscope className="h-4 w-4 text-emerald-500" />
           </div>
 


### PR DESCRIPTION
## Summary

- Both `DoctorSidebar` and `AdminSidebar` used `hidden md:flex`, making them completely invisible on mobile regardless of the toggle button state
- Added `mobileOpen` state to both layouts alongside the existing `collapsed` state
- The hamburger button now uses a viewport-aware handler: opens the mobile drawer (`< 768px`) or toggles desktop collapse (`>= 768px`)
- Sidebars render as a fixed full-height overlay with a semi-transparent backdrop on mobile, sliding in/out via CSS `translate-x` transition

## Test plan

- [ ] On mobile viewport (< 768px): tap the hamburger — sidebar slides in from left as overlay
- [ ] Tapping the backdrop closes the sidebar
- [ ] On desktop (>= 768px): hamburger collapses/expands the inline sidebar as before
- [ ] Both Doctor and Admin dashboards work correctly

https://claude.ai/code/session_015BFjThdycs6MCzGHwJqsv3

---
_Generated by [Claude Code](https://claude.ai/code/session_015BFjThdycs6MCzGHwJqsv3)_