### PR TITLE
Add professional statistics page with charts

### DIFF
--- a/backend/controllers/admin-controller.js
+++ b/backend/controllers/admin-controller.js
@@ -3,6 +3,8 @@ import { matchedData } from "express-validator";
 import { User } from "../models/user.js";
 import { DoctorInvite } from "../models/doctorInvite.js";
 import { sendDoctorInviteEmail, sendWelcomeEmail } from "../mail/emails.js";
+import Appointment from "../models/Appointment.js";
+import { Prescription } from "../models/prescription.js";
 
 const DAYS_OF_WEEK = [
   "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
@@ -350,6 +352,101 @@ export const getStats = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Server error fetching stats",
+    });
+  }
+};
+
+export const getDetailedStats = async (req, res) => {
+  try {
+    const twelveMonthsAgo = new Date();
+    twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 11);
+    twelveMonthsAgo.setDate(1);
+    twelveMonthsAgo.setHours(0, 0, 0, 0);
+
+    const [
+      userResults,
+      appointmentResults,
+      topMedicines,
+      monthlyUsers,
+      monthlyAppointments,
+    ] = await Promise.all([
+      User.aggregate([{ $group: { _id: "$role", count: { $sum: 1 } } }]),
+
+      Appointment.aggregate([
+        { $group: { _id: "$status", count: { $sum: 1 } } },
+      ]),
+
+      Prescription.aggregate([
+        { $unwind: "$medications" },
+        { $group: { _id: "$medications.medicine", count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+        { $project: { _id: 0, medicine: "$_id", count: 1 } },
+      ]),
+
+      User.aggregate([
+        { $match: { createdAt: { $gte: twelveMonthsAgo } } },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$createdAt" },
+              month: { $month: "$createdAt" },
+              role: "$role",
+            },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { "_id.year": 1, "_id.month": 1 } },
+      ]),
+
+      Appointment.aggregate([
+        { $match: { createdAt: { $gte: twelveMonthsAgo } } },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$createdAt" },
+              month: { $month: "$createdAt" },
+              status: "$status",
+            },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { "_id.year": 1, "_id.month": 1 } },
+      ]),
+    ]);
+
+    const byRole = Object.fromEntries(userResults.map((r) => [r._id, r.count]));
+    const byStatus = Object.fromEntries(
+      appointmentResults.map((r) => [r._id, r.count])
+    );
+
+    return res.status(200).json({
+      success: true,
+      stats: {
+        users: {
+          total: userResults.reduce((sum, r) => sum + r.count, 0),
+          doctor: byRole.doctor ?? 0,
+          patient: byRole.patient ?? 0,
+          admin: byRole.admin ?? 0,
+          superadmin: byRole.superadmin ?? 0,
+        },
+        appointments: {
+          total: appointmentResults.reduce((sum, r) => sum + r.count, 0),
+          pending: byStatus.pending ?? 0,
+          confirmed: byStatus.confirmed ?? 0,
+          completed: byStatus.completed ?? 0,
+          cancelled: byStatus.cancelled ?? 0,
+        },
+        topMedicines,
+        monthlyUsers,
+        monthlyAppointments,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching detailed stats:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Server error fetching detailed stats",
     });
   }
 };

--- a/backend/routes/admin-routes.js
+++ b/backend/routes/admin-routes.js
@@ -5,6 +5,7 @@ import {
   updateUserRole,
   getAllUsers,
   getStats,
+  getDetailedStats,
   verifyUserManually,
   deleteUserByAdmin,
 } from "../controllers/admin-controller.js";
@@ -15,6 +16,7 @@ import { createDoctorInviteValidation } from "../validators/adminValidators.js";
 const router = express.Router();
 router.get("/users", verifyToken, requireRole("admin"), requireCsrf, getAllUsers);
 router.get("/stats", verifyToken, requireRole("admin"), requireCsrf, getStats);
+router.get("/detailed-stats", verifyToken, requireRole("admin"), requireCsrf, getDetailedStats);
 router.patch(
   "/users/:id/role",
   verifyToken,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -106,6 +106,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -665,6 +666,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1850,6 +1852,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3853,9 +3856,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4012,6 +4015,7 @@
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4020,8 +4024,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4030,8 +4035,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4101,6 +4107,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4255,9 +4262,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4640,6 +4647,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5160,6 +5168,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5633,7 +5642,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -6348,6 +6358,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6533,6 +6544,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6858,6 +6870,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7673,6 +7686,7 @@
       "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10078,9 +10092,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10222,6 +10236,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10231,6 +10246,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10277,14 +10293,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10423,7 +10440,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11542,6 +11560,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11799,6 +11818,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12431,6 +12451,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "react-hot-toast": "^2.6.0",
         "react-icons": "^5.6.0",
         "react-international-phone": "^4.8.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.11"
       },
@@ -3474,6 +3475,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3500,6 +3537,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3873,6 +3922,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3908,7 +4020,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3918,7 +4030,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3929,6 +4041,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5517,6 +5635,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5604,6 +5843,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -6056,6 +6301,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -6540,6 +6795,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -7501,6 +7762,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7548,6 +7819,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -10000,6 +10280,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -10086,6 +10389,51 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10149,6 +10497,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -11135,7 +11489,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -11709,6 +12062,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.6.0",
     "react-international-phone": "^4.8.0",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.11"
   },

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -7,7 +7,7 @@ export default function AuthLayout({
 }) {
   return (
     <Background>
-      <div className="relative z-10 h-screen w-screen overflow-hidden">
+      <div className="relative z-10 overflow-x-hidden lg:h-screen lg:w-screen lg:overflow-hidden">
         {children}
       </div>
     </Background>

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -96,8 +96,8 @@ export default function LoginForm() {
   };
 
   return (
-    <section className="min-h-screen w-screen overflow-x-hidden bg-[#eef1ee] lg:h-screen lg:overflow-hidden">
-      <div className="grid min-h-screen w-full grid-cols-1 lg:h-full lg:grid-cols-[1.08fr_0.92fr]">
+    <section className="w-screen overflow-x-hidden bg-[#eef1ee] lg:h-screen lg:overflow-hidden">
+      <div className="grid w-full grid-cols-1 lg:h-full lg:grid-cols-[1.08fr_0.92fr]">
         {/* LEFT PANEL */}
         <div className="relative hidden h-full overflow-hidden bg-gradient-to-br from-[#eef2ef] via-[#edf3ef] to-[#e7eeea] lg:flex">
           <div className="pointer-events-none absolute inset-0">
@@ -129,7 +129,7 @@ export default function LoginForm() {
         </div>
 
         {/* RIGHT PANEL */}
-        <div className="relative flex w-full flex-col items-center justify-start overflow-y-auto bg-gradient-to-br from-[#edf5f1] via-[#e8f1eb] to-[#e1ebe4] px-8 py-12 sm:px-12 lg:h-full lg:justify-center lg:px-14 xl:px-20">
+        <div className="relative flex w-full flex-col items-center justify-center bg-gradient-to-br from-[#edf5f1] via-[#e8f1eb] to-[#e1ebe4] px-8 py-12 sm:px-12 lg:h-full lg:overflow-y-auto lg:px-14 xl:px-20">
           <div className="pointer-events-none absolute inset-0">
             <div className="absolute right-[10%] top-[14%] h-56 w-56 rounded-full bg-emerald-500/4 blur-3xl" />
             <div className="absolute left-[6%] bottom-[10%] h-64 w-64 rounded-full bg-lime-400/3 blur-3xl" />
@@ -139,7 +139,7 @@ export default function LoginForm() {
             initial={{ opacity: 0, x: 24 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.45 }}
-            className="relative z-10 w-full max-w-[470px] lg:my-auto"
+            className="relative z-10 w-full max-w-[470px]"
           >
             <div className="mb-12 flex flex-col items-center text-center">
               <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#dbe5df] ring-1 ring-[#cad7d0]">

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Eye, EyeOff, Loader2, ChevronDown, Zap } from "lucide-react";
+import { Eye, EyeOff, Loader2, ChevronDown } from "lucide-react";
 import Link from "next/link";
 
 import { useAuthStore } from "@/store/authStore";
@@ -322,8 +322,7 @@ export default function LoginForm() {
                 type="button"
                 onClick={() => setDemoOpen((o) => !o)}
                 className="flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-emerald-300 bg-emerald-50/60 px-4 py-2.5 text-sm font-medium text-emerald-700 transition hover:bg-emerald-100/60 cursor-pointer select-none"
-              >
-                <Zap className="h-4 w-4" />
+              >              
                 Demo Access — try it instantly
                 <ChevronDown
                   className={`h-4 w-4 transition-transform duration-200 ${demoOpen ? "rotate-180" : ""}`}

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -96,8 +96,8 @@ export default function LoginForm() {
   };
 
   return (
-    <section className="h-screen w-screen overflow-hidden bg-[#eef1ee]">
-      <div className="grid h-full w-full grid-cols-1 lg:grid-cols-[1.08fr_0.92fr]">
+    <section className="min-h-screen w-screen overflow-x-hidden bg-[#eef1ee] lg:h-screen lg:overflow-hidden">
+      <div className="grid min-h-screen w-full grid-cols-1 lg:h-full lg:grid-cols-[1.08fr_0.92fr]">
         {/* LEFT PANEL */}
         <div className="relative hidden h-full overflow-hidden bg-gradient-to-br from-[#eef2ef] via-[#edf3ef] to-[#e7eeea] lg:flex">
           <div className="pointer-events-none absolute inset-0">
@@ -129,7 +129,7 @@ export default function LoginForm() {
         </div>
 
         {/* RIGHT PANEL */}
-        <div className="relative flex h-full w-full items-center justify-center bg-gradient-to-br from-[#edf5f1] via-[#e8f1eb] to-[#e1ebe4] px-8 py-10 sm:px-12 lg:px-14 xl:px-20">
+        <div className="relative flex w-full flex-col items-center justify-start overflow-y-auto bg-gradient-to-br from-[#edf5f1] via-[#e8f1eb] to-[#e1ebe4] px-8 py-12 sm:px-12 lg:h-full lg:justify-center lg:px-14 xl:px-20">
           <div className="pointer-events-none absolute inset-0">
             <div className="absolute right-[10%] top-[14%] h-56 w-56 rounded-full bg-emerald-500/4 blur-3xl" />
             <div className="absolute left-[6%] bottom-[10%] h-64 w-64 rounded-full bg-lime-400/3 blur-3xl" />
@@ -139,7 +139,7 @@ export default function LoginForm() {
             initial={{ opacity: 0, x: 24 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.45 }}
-            className="relative z-10 w-full max-w-[470px]"
+            className="relative z-10 w-full max-w-[470px] lg:my-auto"
           >
             <div className="mb-12 flex flex-col items-center text-center">
               <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#dbe5df] ring-1 ring-[#cad7d0]">

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -351,16 +351,16 @@ export default function LoginForm() {
                             setCharacterMood("idle");
                             setGazeMode("follow");
                           }}
-                          className={`flex flex-col items-start gap-2 rounded-xl border p-3 text-left transition cursor-pointer ${acc.bg}`}
+                          className={`flex flex-col items-start gap-1.5 rounded-xl border p-2 sm:p-3 text-left transition cursor-pointer ${acc.bg}`}
                         >
-                          <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${acc.tag}`}>
+                          <span className={`rounded-full px-1.5 py-0.5 text-[10px] sm:text-[11px] font-semibold ${acc.tag}`}>
                             {acc.role}
                           </span>
-                          <div className="w-full space-y-0.5">
-                            <p className="truncate text-[11px] text-gray-500">{acc.email}</p>
-                            <p className="text-[11px] font-mono text-gray-400">{acc.password}</p>
+                          <div className="w-full min-w-0 space-y-0.5">
+                            <p className="truncate text-[10px] sm:text-[11px] text-gray-500">{acc.email}</p>
+                            <p className="truncate text-[10px] sm:text-[11px] font-mono text-gray-400">{acc.password}</p>
                           </div>
-                          <span className="text-[10px] font-medium text-gray-400">click to fill ↗</span>
+                          <span className="text-[9px] sm:text-[10px] font-medium text-gray-400">tap to fill ↗</span>
                         </button>
                       ))}
                     </div>

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { motion } from "framer-motion";
-import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Eye, EyeOff, Loader2, ChevronDown, Zap } from "lucide-react";
 import Link from "next/link";
 
 import { useAuthStore } from "@/store/authStore";
@@ -11,9 +11,16 @@ import LoginCharacter, {
   GazeMode,
 } from "@/components/UICharacter";
 
+const DEMO_ACCOUNTS = [
+  { role: "Admin", email: "admin@gmail.com", password: "admin1234", color: "from-orange-400 to-amber-500", bg: "bg-orange-50 border-orange-200 hover:border-orange-400", tag: "bg-orange-100 text-orange-700" },
+  { role: "Doctor", email: "doctor@gmail.com", password: "doctor1234", color: "from-cyan-500 to-blue-500", bg: "bg-cyan-50 border-cyan-200 hover:border-cyan-400", tag: "bg-cyan-100 text-cyan-700" },
+  { role: "Patient", email: "user@gmail.com", password: "user1234", color: "from-violet-500 to-purple-500", bg: "bg-violet-50 border-violet-200 hover:border-violet-400", tag: "bg-violet-100 text-violet-700" },
+];
+
 export default function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [demoOpen, setDemoOpen] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -309,7 +316,60 @@ export default function LoginForm() {
               </motion.button>
             </form>
 
-            <p className="mt-14 text-center text-sm text-[#727d77]">
+            {/* Demo credentials */}
+            <div className="mt-10">
+              <button
+                type="button"
+                onClick={() => setDemoOpen((o) => !o)}
+                className="flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-emerald-300 bg-emerald-50/60 px-4 py-2.5 text-sm font-medium text-emerald-700 transition hover:bg-emerald-100/60 cursor-pointer select-none"
+              >
+                <Zap className="h-4 w-4" />
+                Demo Access — try it instantly
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform duration-200 ${demoOpen ? "rotate-180" : ""}`}
+                />
+              </button>
+
+              <AnimatePresence>
+                {demoOpen && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.22 }}
+                    className="overflow-hidden"
+                  >
+                    <div className="grid grid-cols-3 gap-2 pt-3">
+                      {DEMO_ACCOUNTS.map((acc) => (
+                        <button
+                          key={acc.role}
+                          type="button"
+                          onClick={() => {
+                            setEmail(acc.email);
+                            setPassword(acc.password);
+                            setDemoOpen(false);
+                            setCharacterMood("idle");
+                            setGazeMode("follow");
+                          }}
+                          className={`flex flex-col items-start gap-2 rounded-xl border p-3 text-left transition cursor-pointer ${acc.bg}`}
+                        >
+                          <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${acc.tag}`}>
+                            {acc.role}
+                          </span>
+                          <div className="w-full space-y-0.5">
+                            <p className="truncate text-[11px] text-gray-500">{acc.email}</p>
+                            <p className="text-[11px] font-mono text-gray-400">{acc.password}</p>
+                          </div>
+                          <span className="text-[10px] font-medium text-gray-400">click to fill ↗</span>
+                        </button>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            <p className="mt-6 text-center text-sm text-[#727d77]">
               Don&apos;t Have An Account?{" "}
               <Link
                 href="/signup"

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -4,9 +4,7 @@ import LoginForm from "./LoginForm";
 export default function Page() {
   return (
     <GuestOnly>
-      <div className="h-screen w-screen overflow-hidden">
-        <LoginForm />
-      </div>
+      <LoginForm />
     </GuestOnly>
   );
 }

--- a/frontend/src/app/(protected)/admin/add-doctor/page.tsx
+++ b/frontend/src/app/(protected)/admin/add-doctor/page.tsx
@@ -26,7 +26,7 @@ export default function AddDoctorPage() {
   };
 
   return (
-    <div className="max-w-2xl w-xl mx-auto rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl backdrop-blur-xl text-white">
+    <div className="w-full max-w-2xl mx-auto rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl backdrop-blur-xl text-white">
       <div className="flex flex-col items-center">
         <h1 className="text-3xl font-bold bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-transparent">
           Add Doctor

--- a/frontend/src/app/(protected)/admin/statistics/page.tsx
+++ b/frontend/src/app/(protected)/admin/statistics/page.tsx
@@ -1,12 +1,569 @@
-export default function AdminStatisticsPage() {
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import axios from "axios";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Users,
+  Stethoscope,
+  CalendarCheck,
+  CheckCircle,
+  TrendingUp,
+  Pill,
+  Activity,
+  UserPlus,
+} from "lucide-react";
+import { useAuthStore } from "@/store/authStore";
+
+const api = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`,
+  withCredentials: true,
+});
+
+type MonthlyUserEntry = {
+  _id: { year: number; month: number; role: string };
+  count: number;
+};
+
+type MonthlyAppointmentEntry = {
+  _id: { year: number; month: number; status: string };
+  count: number;
+};
+
+type DetailedStats = {
+  users: {
+    total: number;
+    doctor: number;
+    patient: number;
+    admin: number;
+    superadmin: number;
+  };
+  appointments: {
+    total: number;
+    pending: number;
+    confirmed: number;
+    completed: number;
+    cancelled: number;
+  };
+  topMedicines: { medicine: string; count: number }[];
+  monthlyUsers: MonthlyUserEntry[];
+  monthlyAppointments: MonthlyAppointmentEntry[];
+};
+
+const APPOINTMENT_COLORS = {
+  completed: "#10b981",
+  confirmed: "#3b82f6",
+  pending: "#f59e0b",
+  cancelled: "#ef4444",
+};
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+function buildMonthLabels(): { year: number; month: number; label: string }[] {
+  const now = new Date();
+  return Array.from({ length: 12 }, (_, i) => {
+    const d = new Date(now.getFullYear(), now.getMonth() - 11 + i, 1);
+    return {
+      year: d.getFullYear(),
+      month: d.getMonth() + 1,
+      label: `${MONTH_NAMES[d.getMonth()]} ${String(d.getFullYear()).slice(2)}`,
+    };
+  });
+}
+
+function buildMonthlyUserData(raw: MonthlyUserEntry[]) {
+  const labels = buildMonthLabels();
+  return labels.map(({ year, month, label }) => {
+    const entries = raw.filter(
+      (e) => e._id.year === year && e._id.month === month
+    );
+    const doc = entries.find((e) => e._id.role === "doctor")?.count ?? 0;
+    const pat = entries.find((e) => e._id.role === "patient")?.count ?? 0;
+    return { label, Doctors: doc, Patients: pat };
+  });
+}
+
+function buildMonthlyAppointmentData(raw: MonthlyAppointmentEntry[]) {
+  const labels = buildMonthLabels();
+  return labels.map(({ year, month, label }) => {
+    const entries = raw.filter(
+      (e) => e._id.year === year && e._id.month === month
+    );
+    const total = entries.reduce((s, e) => s + e.count, 0);
+    const completed =
+      entries.find((e) => e._id.status === "completed")?.count ?? 0;
+    return { label, Total: total, Completed: completed };
+  });
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  color,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: number;
+  color: string;
+}) {
   return (
-    <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl backdrop-blur-xl text-white">
-      <h2 className="text-3xl font-bold bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-transparent">
-        Statistics
-      </h2>
-      <p className="mt-2 text-sm text-gray-400">
-        This page will show platform stats and insights once you build analytics.
-      </p>
+    <div className="rounded-2xl border border-gray-700/60 bg-gray-800/50 p-5 backdrop-blur-sm flex items-center gap-4">
+      <div className={`rounded-xl p-3 ${color}`}>
+        <Icon className="h-6 w-6 text-white" />
+      </div>
+      <div>
+        <p className="text-xs text-gray-400 uppercase tracking-wider font-medium">
+          {label}
+        </p>
+        <p className="text-3xl font-bold text-white mt-0.5">
+          {value.toLocaleString()}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-700/60 bg-gray-800/50 p-6 backdrop-blur-sm">
+      <div className="mb-5">
+        <h3 className="text-lg font-semibold text-white">{title}</h3>
+        {subtitle && (
+          <p className="text-xs text-gray-400 mt-0.5">{subtitle}</p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const CustomTooltip = ({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { name: string; value: number; color: string }[];
+  label?: string;
+}) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-xl border border-gray-600 bg-gray-900 p-3 shadow-xl text-sm">
+      {label && <p className="text-gray-300 font-medium mb-2">{label}</p>}
+      {payload.map((p) => (
+        <p key={p.name} style={{ color: p.color }}>
+          {p.name}: <span className="font-bold">{p.value.toLocaleString()}</span>
+        </p>
+      ))}
+    </div>
+  );
+};
+
+export default function AdminStatisticsPage() {
+  const [stats, setStats] = useState<DetailedStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { csrfToken, fetchCsrfToken } = useAuthStore();
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      let token = csrfToken;
+      if (!token) {
+        await fetchCsrfToken();
+        token = useAuthStore.getState().csrfToken;
+      }
+      const res = await api.get("/admin/detailed-stats", {
+        headers: { "x-csrf-token": token ?? "" },
+      });
+      setStats(res.data.stats);
+    } catch (err) {
+      setError(
+        axios.isAxiosError(err)
+          ? (err.response?.data as { message?: string })?.message ??
+              "Failed to load statistics"
+          : "Failed to load statistics"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [csrfToken, fetchCsrfToken]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-emerald-500 border-t-transparent" />
+          <p className="text-gray-400 text-sm">Loading statistics…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !stats) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-8 text-center max-w-sm">
+          <Activity className="mx-auto h-10 w-10 text-red-400 mb-3" />
+          <p className="text-red-300 font-medium">{error ?? "No data available"}</p>
+          <button
+            onClick={fetchStats}
+            className="mt-4 rounded-xl bg-emerald-600 px-5 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const appointmentPieData = [
+    { name: "Completed", value: stats.appointments.completed, color: APPOINTMENT_COLORS.completed },
+    { name: "Confirmed", value: stats.appointments.confirmed, color: APPOINTMENT_COLORS.confirmed },
+    { name: "Pending", value: stats.appointments.pending, color: APPOINTMENT_COLORS.pending },
+    { name: "Cancelled", value: stats.appointments.cancelled, color: APPOINTMENT_COLORS.cancelled },
+  ].filter((d) => d.value > 0);
+
+  const userPieData = [
+    { name: "Patients", value: stats.users.patient, color: "#8b5cf6" },
+    { name: "Doctors", value: stats.users.doctor, color: "#06b6d4" },
+    { name: "Admins", value: stats.users.admin + stats.users.superadmin, color: "#f97316" },
+  ].filter((d) => d.value > 0);
+
+  const monthlyUserData = buildMonthlyUserData(stats.monthlyUsers);
+  const monthlyApptData = buildMonthlyAppointmentData(stats.monthlyAppointments);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="rounded-2xl border border-gray-700/60 bg-gray-800/50 px-6 py-5 backdrop-blur-sm">
+        <h2 className="text-2xl font-bold bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-transparent">
+          Platform Statistics
+        </h2>
+        <p className="mt-1 text-sm text-gray-400">
+          Real-time overview of users, appointments, and prescriptions
+        </p>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+        <StatCard
+          icon={Users}
+          label="Total Users"
+          value={stats.users.total}
+          color="bg-violet-600"
+        />
+        <StatCard
+          icon={Stethoscope}
+          label="Doctors"
+          value={stats.users.doctor}
+          color="bg-cyan-600"
+        />
+        <StatCard
+          icon={UserPlus}
+          label="Patients"
+          value={stats.users.patient}
+          color="bg-purple-600"
+        />
+        <StatCard
+          icon={CalendarCheck}
+          label="Total Appointments"
+          value={stats.appointments.total}
+          color="bg-blue-600"
+        />
+        <StatCard
+          icon={CheckCircle}
+          label="Completed"
+          value={stats.appointments.completed}
+          color="bg-emerald-600"
+        />
+      </div>
+
+      {/* Pie Charts Row */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <ChartCard
+          title="Appointment Status"
+          subtitle="Distribution by status"
+        >
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={appointmentPieData}
+                cx="50%"
+                cy="50%"
+                innerRadius={70}
+                outerRadius={110}
+                paddingAngle={3}
+                dataKey="value"
+              >
+                {appointmentPieData.map((entry, i) => (
+                  <Cell key={i} fill={entry.color} stroke="transparent" />
+                ))}
+              </Pie>
+              <Tooltip
+                content={<CustomTooltip />}
+              />
+              <Legend
+                formatter={(value) => (
+                  <span className="text-gray-300 text-sm">{value}</span>
+                )}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="User Distribution" subtitle="By role">
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={userPieData}
+                cx="50%"
+                cy="50%"
+                innerRadius={70}
+                outerRadius={110}
+                paddingAngle={3}
+                dataKey="value"
+              >
+                {userPieData.map((entry, i) => (
+                  <Cell key={i} fill={entry.color} stroke="transparent" />
+                ))}
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+              <Legend
+                formatter={(value) => (
+                  <span className="text-gray-300 text-sm">{value}</span>
+                )}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+
+      {/* Top 10 Prescribed Medicines */}
+      <ChartCard
+        title="Top 10 Most Prescribed Medicines"
+        subtitle="Total prescription count across all doctors"
+      >
+        {stats.topMedicines.length === 0 ? (
+          <div className="flex h-64 items-center justify-center">
+            <div className="text-center">
+              <Pill className="mx-auto h-10 w-10 text-gray-600 mb-2" />
+              <p className="text-gray-500 text-sm">No prescription data yet</p>
+            </div>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart
+              data={stats.topMedicines}
+              layout="vertical"
+              margin={{ left: 8, right: 24, top: 0, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                horizontal={false}
+                stroke="#374151"
+              />
+              <XAxis
+                type="number"
+                tick={{ fill: "#9ca3af", fontSize: 12 }}
+                axisLine={{ stroke: "#374151" }}
+                tickLine={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="medicine"
+                width={160}
+                tick={{ fill: "#d1d5db", fontSize: 12 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: "#ffffff08" }} />
+              <Bar dataKey="count" name="Prescriptions" radius={[0, 6, 6, 0]}>
+                {stats.topMedicines.map((_, i) => {
+                  const hue = 140 + i * 8;
+                  return (
+                    <Cell
+                      key={i}
+                      fill={`hsl(${hue}, 65%, ${52 - i * 2}%)`}
+                    />
+                  );
+                })}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </ChartCard>
+
+      {/* Monthly Trends */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <ChartCard
+          title="New Registrations"
+          subtitle="Doctors & patients registered in the last 12 months"
+        >
+          <ResponsiveContainer width="100%" height={260}>
+            <LineChart
+              data={monthlyUserData}
+              margin={{ left: -10, right: 8, top: 4, bottom: 0 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={{ stroke: "#374151" }}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                allowDecimals={false}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend
+                formatter={(v) => (
+                  <span className="text-gray-300 text-sm">{v}</span>
+                )}
+              />
+              <Line
+                type="monotone"
+                dataKey="Doctors"
+                stroke="#06b6d4"
+                strokeWidth={2}
+                dot={{ r: 3, fill: "#06b6d4" }}
+                activeDot={{ r: 5 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="Patients"
+                stroke="#8b5cf6"
+                strokeWidth={2}
+                dot={{ r: 3, fill: "#8b5cf6" }}
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard
+          title="Appointment Trends"
+          subtitle="Total vs completed appointments in the last 12 months"
+        >
+          <ResponsiveContainer width="100%" height={260}>
+            <BarChart
+              data={monthlyApptData}
+              margin={{ left: -10, right: 8, top: 4, bottom: 0 }}
+              barCategoryGap="30%"
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={{ stroke: "#374151" }}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                allowDecimals={false}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: "#ffffff08" }} />
+              <Legend
+                formatter={(v) => (
+                  <span className="text-gray-300 text-sm">{v}</span>
+                )}
+              />
+              <Bar dataKey="Total" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="Completed" fill="#10b981" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+
+      {/* Appointment Status Breakdown */}
+      <ChartCard
+        title="Appointment Breakdown"
+        subtitle="Status counts at a glance"
+      >
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {(
+            [
+              { label: "Booked / Pending", value: stats.appointments.pending, color: "text-amber-400", bg: "bg-amber-400/10 border-amber-400/20" },
+              { label: "Confirmed", value: stats.appointments.confirmed, color: "text-blue-400", bg: "bg-blue-400/10 border-blue-400/20" },
+              { label: "Completed", value: stats.appointments.completed, color: "text-emerald-400", bg: "bg-emerald-400/10 border-emerald-400/20" },
+              { label: "Cancelled", value: stats.appointments.cancelled, color: "text-red-400", bg: "bg-red-400/10 border-red-400/20" },
+            ] as const
+          ).map(({ label, value, color, bg }) => (
+            <div
+              key={label}
+              className={`rounded-xl border p-4 ${bg} text-center`}
+            >
+              <p className={`text-4xl font-bold ${color}`}>
+                {value.toLocaleString()}
+              </p>
+              <p className="mt-1 text-xs text-gray-400 font-medium uppercase tracking-wider">
+                {label}
+              </p>
+              {stats.appointments.total > 0 && (
+                <p className="mt-1 text-xs text-gray-500">
+                  {Math.round((value / stats.appointments.total) * 100)}%
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </ChartCard>
+
+      {/* Summary insight */}
+      <div className="rounded-2xl border border-gray-700/60 bg-gray-800/30 px-6 py-4 flex items-center gap-3">
+        <TrendingUp className="h-5 w-5 text-emerald-400 shrink-0" />
+        <p className="text-sm text-gray-400">
+          <span className="text-white font-semibold">
+            {stats.appointments.total > 0
+              ? Math.round(
+                  (stats.appointments.completed / stats.appointments.total) * 100
+                )
+              : 0}
+            % completion rate
+          </span>{" "}
+          across {stats.appointments.total.toLocaleString()} total appointments
+          {stats.topMedicines[0]
+            ? ` · Most prescribed: ${stats.topMedicines[0].medicine} (${stats.topMedicines[0].count}×)`
+            : ""}
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -126,15 +126,17 @@
   }
 }
 .custom-tabs-list {
-  @apply mx-auto flex w-fit items-center gap-2 rounded-xl border border-gray-700
-  bg-gray-900/60 p-1 backdrop-blur-xl shadow-lg;
+  @apply mx-auto flex w-full items-center gap-1 rounded-xl border border-gray-700
+  bg-gray-900/60 p-1 backdrop-blur-xl shadow-lg
+  sm:w-fit sm:gap-2;
 }
 
 .custom-tabs-trigger {
-  @apply px-8 py-2 text-sm font-semibold text-gray-300
-  transition-all duration-200 ease-out
-  hover:text-white hover:bg-gray-800/70 hover:scale-[1.03]
+  @apply flex-1 px-3 py-2 text-xs font-semibold text-gray-300 text-center
+  transition-all duration-200 ease-out rounded-lg
+  hover:text-white hover:bg-gray-800/70
   active:scale-95 cursor-pointer
+  sm:flex-none sm:px-8 sm:text-sm
   data-[state=active]:bg-gradient-to-r
   data-[state=active]:from-green-500
   data-[state=active]:to-emerald-600
@@ -144,8 +146,9 @@
 }
 
 .custom-tabs-content {
-  @apply mt-6 rounded-2xl border border-gray-800 bg-gray-900/70
-  p-6 text-white shadow-xl backdrop-blur-xl;
+  @apply mt-4 rounded-2xl border border-gray-800 bg-gray-900/70
+  p-3 text-white shadow-xl backdrop-blur-xl
+  sm:mt-6 sm:p-6;
 }
 /* .glass-panel {
   @apply bg-gray-900/70 backdrop-blur-xl border border-gray-800 shadow-xl rounded-2xl;

--- a/frontend/src/components/AvailabilityScheduler.tsx
+++ b/frontend/src/components/AvailabilityScheduler.tsx
@@ -239,53 +239,54 @@ export default function AvailabilityScheduler({ value, onChange, forceDark }: Pr
                 onChange={() => toggleDay(dayIdx)}
                 forceDark={forceDark}
               />
-              <span className={`w-24 text-sm font-semibold select-none ${labelColor(day.enabled)}`}>
+              <span className={`flex-1 text-sm font-semibold select-none ${labelColor(day.enabled)}`}>
                 {day.day}
               </span>
-
-              {day.enabled ? (
-                <div className="flex flex-1 flex-wrap items-center gap-2">
-                  {day.slots.map((slot, slotIdx) => (
-                    <div key={slotIdx} className="flex items-center gap-1.5">
-                      <TimeInput
-                        value={slot.startTime}
-                        onChange={(v) => updateSlot(dayIdx, slotIdx, "startTime", v)}
-                        forceDark={forceDark}
-                      />
-                      <Clock
-                        className={`h-3.5 w-3.5 shrink-0 ${forceDark ? "text-gray-600" : "text-gray-400 dark:text-gray-600"}`}
-                      />
-                      <TimeInput
-                        value={slot.endTime}
-                        onChange={(v) => updateSlot(dayIdx, slotIdx, "endTime", v)}
-                        forceDark={forceDark}
-                      />
-                      {day.slots.length > 1 && (
-                        <button
-                          type="button"
-                          onClick={() => removeSlot(dayIdx, slotIdx)}
-                          className={`transition-colors cursor-pointer ${removeSlotColor}`}
-                          aria-label="Remove slot"
-                        >
-                          <X className="h-3.5 w-3.5" />
-                        </button>
-                      )}
-                    </div>
-                  ))}
-
-                  <button
-                    type="button"
-                    onClick={() => addSlot(dayIdx)}
-                    className={`inline-flex items-center gap-1 text-xs font-medium transition-colors cursor-pointer ${addSlotColor}`}
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    Add slot
-                  </button>
-                </div>
-              ) : (
+              {!day.enabled && (
                 <span className={`text-xs ${unavailableText}`}>Unavailable</span>
               )}
             </div>
+
+            {/* Slots section — stacked for mobile friendliness */}
+            {day.enabled && (
+              <div className="space-y-2 px-3 pb-3">
+                {day.slots.map((slot, slotIdx) => (
+                  <div key={slotIdx} className="flex items-center gap-2">
+                    <TimeInput
+                      value={slot.startTime}
+                      onChange={(v) => updateSlot(dayIdx, slotIdx, "startTime", v)}
+                      forceDark={forceDark}
+                    />
+                    <Clock
+                      className={`h-3.5 w-3.5 shrink-0 ${forceDark ? "text-gray-600" : "text-gray-400 dark:text-gray-600"}`}
+                    />
+                    <TimeInput
+                      value={slot.endTime}
+                      onChange={(v) => updateSlot(dayIdx, slotIdx, "endTime", v)}
+                      forceDark={forceDark}
+                    />
+                    {day.slots.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeSlot(dayIdx, slotIdx)}
+                        className={`ml-auto transition-colors cursor-pointer ${removeSlotColor}`}
+                        aria-label="Remove slot"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => addSlot(dayIdx)}
+                  className={`inline-flex items-center gap-1 text-xs font-medium transition-colors cursor-pointer ${addSlotColor}`}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add slot
+                </button>
+              </div>
+            )}
 
             {/* Inline error */}
             {dayError && (

--- a/frontend/src/components/dashboard/admin/AdminSidebar.tsx
+++ b/frontend/src/components/dashboard/admin/AdminSidebar.tsx
@@ -127,6 +127,7 @@ export default function AdminSidebar({ collapsed, onToggle, mobileOpen, onMobile
                 key={item.href}
                 href={item.href}
                 title={collapsed ? item.label : undefined}
+                onClick={onMobileClose}
                 className={[
                   "group flex items-center rounded-2xl text-sm font-medium transition-all duration-200",
                   collapsed ? "justify-center px-3 py-3" : "gap-3 px-4 py-3",

--- a/frontend/src/components/dashboard/admin/AdminTable.tsx
+++ b/frontend/src/components/dashboard/admin/AdminTable.tsx
@@ -680,7 +680,151 @@ const AdminTable = ({
           </div>
         )}
 
-        <div className="overflow-x-auto rounded-2xl border border-gray-800 bg-gray-950/40 shadow-lg">
+        {/* Mobile card list */}
+        <div className="lg:hidden space-y-3">
+          {filteredUsers.length === 0 ? (
+            <p className="py-8 text-center text-sm text-gray-400">{meta.empty}</p>
+          ) : (
+            paginatedUsers.map((u) => {
+              const isSelf = u._id === user?._id;
+              const isSuperAdminViewer = user?.role === "superadmin";
+
+              const canSelect = isSelf
+                ? false
+                : isSuperAdminViewer
+                  ? u.role !== "superadmin"
+                  : u.role !== "admin" && u.role !== "superadmin";
+
+              const canEditRole = isSelf
+                ? false
+                : isSuperAdminViewer
+                  ? u.role !== "admin" && u.role !== "superadmin"
+                  : u.role !== "admin" && u.role !== "superadmin";
+
+              const canDelete = isSelf
+                ? false
+                : isSuperAdminViewer
+                  ? u.role !== "superadmin"
+                  : u.role !== "admin" && u.role !== "superadmin";
+
+              const canVerifyManually =
+                !u.isVerified &&
+                Boolean(u.manualVerificationRequested) &&
+                (isSuperAdminViewer
+                  ? u.role !== "superadmin"
+                  : u.role !== "admin" && u.role !== "superadmin");
+
+              const isSelected = effectiveSelectedUserIds.includes(u._id);
+
+              return (
+                <div
+                  key={u._id}
+                  className={`rounded-2xl border p-4 transition-colors ${
+                    isSelected
+                      ? "border-emerald-500/30 bg-emerald-500/5"
+                      : "border-gray-800 bg-gray-900/40"
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-3">
+                      {canSelect ? (
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={() => toggleRowSelection(u._id)}
+                          aria-label={`Select ${u.name}`}
+                          className="mt-0.5 border-gray-600 data-[state=checked]:bg-emerald-500 data-[state=checked]:border-emerald-500 cursor-pointer"
+                        />
+                      ) : (
+                        <Checkbox
+                          checked={false}
+                          disabled
+                          className="mt-0.5 border-gray-700 opacity-40"
+                        />
+                      )}
+                      <div className="min-w-0">
+                        <p className="font-medium text-white">{u.name}</p>
+                        <p className="truncate text-sm text-gray-400">{u.email}</p>
+                        <p className="mt-1 text-xs text-gray-500">
+                          Joined {u.createdAt ? formatDate(u.createdAt) : "—"} · Last login: {u.lastLogin ? formatDate(u.lastLogin) : "—"}
+                        </p>
+                      </div>
+                    </div>
+                    {!hasMultipleSelectedRows && canDelete && (
+                      <button
+                        type="button"
+                        disabled={isLoading}
+                        onClick={() => handleRowDelete(u)}
+                        className="group inline-flex items-center rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300 transition-all hover:bg-red-500/20 active:scale-95 disabled:opacity-50 cursor-pointer"
+                      >
+                        <Trash2 size={15} className="transition-transform group-hover:rotate-6" />
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize ${badgeClassMap[u.role]}`}>
+                      {u.role}
+                    </span>
+                    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                      u.isVerified
+                        ? "border border-green-500/30 bg-green-500/10 text-green-300"
+                        : "border border-red-500/30 bg-red-500/10 text-red-300"
+                    }`}>
+                      {u.isVerified ? "Verified" : "Unverified"}
+                    </span>
+                    {!hasMultipleSelectedRows && canVerifyManually && (
+                      <button
+                        type="button"
+                        disabled={isLoading}
+                        onClick={() => handleRowManualVerify(u)}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-300 transition-all hover:bg-emerald-500/20 active:scale-95 disabled:opacity-50 cursor-pointer"
+                      >
+                        <ShieldCheck size={13} />
+                        Verify
+                      </button>
+                    )}
+                    {u.manualVerificationRequested && !canVerifyManually && (
+                      <span className="inline-flex rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-xs font-semibold text-amber-300">
+                        Verify Requested
+                      </span>
+                    )}
+                  </div>
+
+                  {!hasMultipleSelectedRows && canEditRole && (
+                    <div className="mt-3">
+                      <Select
+                        value={u.role}
+                        disabled={isLoading}
+                        onValueChange={(value) => handleRowRoleChange(u, value as "doctor" | "patient")}
+                      >
+                        <SelectTrigger className="h-9 w-full border-gray-700 bg-gray-800/80 text-white transition-all hover:border-emerald-500/50 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/30 cursor-pointer">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent className="border border-gray-700 bg-gray-900/95 text-white backdrop-blur-xl shadow-xl">
+                          <SelectItem value="patient" disabled={u.role === "patient"} className="cursor-pointer focus:bg-emerald-500/20 focus:text-white">
+                            <div className="flex items-center gap-2">
+                              {u.role === "patient" ? <Check className="h-4 w-4 text-emerald-300" /> : <span className="h-4 w-4" />}
+                              <span>Patient</span>
+                            </div>
+                          </SelectItem>
+                          <SelectItem value="doctor" disabled={u.role === "doctor"} className="cursor-pointer focus:bg-emerald-500/20 focus:text-white">
+                            <div className="flex items-center gap-2">
+                              {u.role === "doctor" ? <Check className="h-4 w-4 text-emerald-300" /> : <span className="h-4 w-4" />}
+                              <span>Doctor</span>
+                            </div>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Desktop table */}
+        <div className="hidden lg:block overflow-x-auto rounded-2xl border border-gray-800 bg-gray-950/40 shadow-lg">
           <table className="w-full min-w-[1320px] text-left border-collapse">
             <thead className="bg-gray-900/70">
               <tr className="border-b border-gray-800 text-sm text-gray-300">


### PR DESCRIPTION
## Summary

- New `/api/admin/detailed-stats` backend endpoint that aggregates user counts by role, appointment status distribution, top 10 most prescribed medicines, and 12-month registration/appointment trends using MongoDB aggregation pipelines
- Installed `recharts` in the frontend for data visualization
- Statistics page fully rebuilt with professional dark-themed charts and KPI cards

## What's shown

- **KPI cards**: Total users, doctors, patients, total appointments, completed appointments
- **Donut charts**: Appointment status distribution (pending/confirmed/completed/cancelled) and user role distribution
- **Horizontal bar chart**: Top 10 most prescribed medicines with prescription counts
- **Line chart**: Monthly new registrations (doctors vs patients) for last 12 months
- **Bar chart**: Monthly appointment trends (total vs completed) for last 12 months
- **Status breakdown grid**: Per-status counts with percentage of total

## Test plan

- [ ] Navigate to Admin → Statistics page
- [ ] Verify KPI cards show correct counts
- [ ] Verify charts render with data (or empty-state placeholders if no data)
- [ ] Verify top medicines bar chart populates after prescriptions are created
- [ ] Verify monthly trend charts show last 12 months

https://claude.ai/code/session_01QU7iP9NqPEiHJc55SRnnCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU7iP9NqPEiHJc55SRnnCk)_