### PR TITLE
Fix stale auth cache causing re-login after logout

### DIFF
--- a/backend/controllers/auth-controller.js
+++ b/backend/controllers/auth-controller.js
@@ -285,7 +285,11 @@ export const checkAuth = async (req, res) => {
       { heartbeatExpiresAt: new Date(Date.now() + 2 * 60 * 1000) },
     );
 
-    res.set("Cache-Control", "private, max-age=30");
+    // Must never be cached by the browser: a page reload right after logout
+    // (or after the session expires) must always hit the server, otherwise a
+    // stale cached "Authenticated" response makes the client look logged in
+    // even though the session cookie was already cleared.
+    res.set("Cache-Control", "no-store");
 
     return res.status(200).json({
       success: true,


### PR DESCRIPTION
## Summary
- Logging out and then reloading the login page (or navigating to the landing page) within 30 seconds would silently re-log the user in.
- Root cause: `GET /api/auth/check-auth` set `Cache-Control: private, max-age=30`. Browsers honor that header for XHR/fetch GET requests, so a page reload shortly after logout replayed the browser's **cached** "Authenticated" response instead of hitting the server — even though the session cookie had already been cleared server-side.
- Fix: mark the `check-auth` response `Cache-Control: no-store` so it's never served stale. The client already throttles redundant `checkAuth` calls in-memory (`lastCheckAuthAt` in `authStore.tsx`) for SPA navigation, so there's no regression to the intended performance optimization — this only removes the browser-level cache that caused the bug across full page reloads.

## Test plan
- [ ] Log in, log out, and immediately reload the login/landing page — confirm the user stays logged out.
- [ ] Confirm normal SPA navigation still avoids redundant `check-auth` network calls (client throttle still in effect).
- [ ] Confirm the auth heartbeat (silent `checkAuth` every 45s) still keeps an active session alive.


---
_Generated by [Claude Code](https://claude.ai/code/session_013PDhsprhGQg6YJuoMRZ7qt)_