### PR TITLE
Fix logout not clearing auth cookies in production

### DIFF
--- a/backend/controllers/auth-controller.js
+++ b/backend/controllers/auth-controller.js
@@ -176,8 +176,14 @@ export const logout = async (req, res) => {
     console.error("Error clearing session on logout:", error);
   }
 
-  res.clearCookie("token", { path: "/" });
-  res.clearCookie("csrfToken", { path: "/" });
+  const isProduction = process.env.NODE_ENV === "production";
+  const cookieOptions = {
+    path: "/",
+    secure: isProduction,
+    sameSite: isProduction ? "none" : "lax",
+  };
+  res.clearCookie("token", { ...cookieOptions, httpOnly: true });
+  res.clearCookie("csrfToken", { ...cookieOptions, httpOnly: false });
 
   return res.status(200).json({
     success: true,
@@ -333,7 +339,13 @@ export const deletePendingSignup = async (req, res) => {
 
     await User.findByIdAndDelete(user._id);
 
-    res.clearCookie("token");
+    const isProduction = process.env.NODE_ENV === "production";
+    res.clearCookie("token", {
+      path: "/",
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? "none" : "lax",
+    });
 
     return res.status(200).json({
       success: true,


### PR DESCRIPTION
## Summary
- `logout()` and `deletePendingSignup()` called `res.clearCookie()` without the `secure`/`sameSite` options that were used when the `token` and `csrfToken` cookies were originally set (`generateTokenAndSetCookie.js`, `csrf.js`).
- Per Express's cookie semantics, a clearing `Set-Cookie` must match the original cookie's `path`/`secure`/`sameSite` attributes to actually take effect in the browser. In production (`secure: true`, `sameSite: "none"`), the mismatched clear calls were silently ignored, so the JWT cookie survived logout.
- Result: after logout, reloading the login page or visiting the landing page re-authenticated the user because the stale `token` cookie was still present and still valid for its remaining lifetime.
- Fixed by passing matching `path`/`secure`/`sameSite`/`httpOnly` options to `res.clearCookie()` in both `logout` and `deletePendingSignup`.

## Test plan
- [ ] Log in, log out, and confirm the `token`/`csrfToken` cookies are actually removed from the browser (both in dev and with `NODE_ENV=production`).
- [ ] After logout, reload the login page and the landing page and confirm the user is no longer authenticated.


---
_Generated by [Claude Code](https://claude.ai/code/session_015HUaA8pKyAEdkAtGjKstzN)_