### PR TITLE
Disable registration when email service is unavailable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ CLIENT_URL=
 MAILTRAP_ACCOUNT_ID=
 MAILTRAP_INBOX_ID=
 MAILTRAP_USE_SANDBOX=
+
+# Frontend (Next.js) — set NEXT_PUBLIC_REGISTRATION_DISABLED=true only on the
+# live/hosted deployment when its mail provider isn't working. Leave unset
+# (or "false") for local dev with MailHog.
+NEXT_PUBLIC_REGISTRATION_DISABLED=

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 🩺 Prescripta
 
+## ⚠️ ⚠️ ⚠️ REGISTRATION CURRENTLY OFFLINE ⚠️ ⚠️ ⚠️
+
+# THIS PROJECT IS NOT CURRENTLY HOSTED WITH A WORKING EMAIL SERVICE.
+
+## New user sign-up, email verification, and password reset all depend on outbound email and are **DISABLED** until this is resolved.
+
+---
+
 A modern, role-based healthcare management platform designed to connect **patients**, **doctors**, and **administrators** in a secure, scalable system.
 
 Built with a focus on **clean UI**, **strict role control**, and **real-world workflow simulation**, Prescripta provides a foundation for digital healthcare platforms.

--- a/backend/controllers/auth-controller.js
+++ b/backend/controllers/auth-controller.js
@@ -58,7 +58,12 @@ export const signup = async (req, res) => {
     generateTokenAndSetCookie(res, user);
     const csrfToken = generateCsrfToken();
     setCsrfCookie(res, csrfToken);
-    await sendVerificationEmail(user.email, verificationToken);
+
+    try {
+      await sendVerificationEmail(user.email, verificationToken);
+    } catch (emailError) {
+      console.error("Failed to send verification email:", emailError);
+    }
 
     return res.status(201).json({
       success: true,
@@ -95,7 +100,12 @@ export const verifyEmail = async (req, res) => {
     user.verificationTokenExpiresAt = undefined;
 
     await user.save();
-    await sendWelcomeEmail(user.email, user.name);
+
+    try {
+      await sendWelcomeEmail(user.email, user.name);
+    } catch (emailError) {
+      console.error("Failed to send welcome email:", emailError);
+    }
 
     return res.status(200).json({
       success: true,

--- a/frontend/src/app/(auth)/signup/SignUpForm.tsx
+++ b/frontend/src/app/(auth)/signup/SignUpForm.tsx
@@ -171,6 +171,8 @@ function PhoneField({
 
 // ── Main sign-up form ─────────────────────────────────────────────────────────
 
+const REGISTRATION_DISABLED = true;
+
 export default function SignUpForm() {
   const { signUp, error, isLoading, clearError, fieldErrors, pendingSignupData } =
     useAuthStore();
@@ -308,7 +310,21 @@ export default function SignUpForm() {
               </h1>
             </div>
 
+            {REGISTRATION_DISABLED && (
+              <p className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-center text-sm font-medium text-amber-800">
+                Registration is temporarily offline. This project isn&apos;t
+                currently hosted with a working email service, so new
+                sign-ups and other actions that require sending email
+                (email verification, password reset) cannot be completed
+                right now.
+              </p>
+            )}
+
             <form onSubmit={handleSignUp} className="space-y-[18px]">
+            <fieldset
+              disabled={REGISTRATION_DISABLED}
+              className="space-y-[18px] disabled:opacity-60"
+            >
               {/* Full Name */}
               <div className="space-y-1.5">
                 <label
@@ -513,16 +529,19 @@ export default function SignUpForm() {
                 whileHover={{ scale: 1.01 }}
                 whileTap={{ scale: 0.985 }}
                 type="submit"
-                disabled={isLoading}
+                disabled={isLoading || REGISTRATION_DISABLED}
                 onFocus={() => setModeAndResetMood("follow")}
                 className="flex h-12 w-full cursor-pointer items-center justify-center rounded-full bg-gradient-to-r from-green-500 to-emerald-600 text-base font-semibold text-white shadow-[0_10px_24px_rgba(16,185,129,0.26)] transition hover:from-green-600 hover:to-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
               >
                 {isLoading ? (
                   <Loader2 className="h-5 w-5 animate-spin" />
+                ) : REGISTRATION_DISABLED ? (
+                  "Registration Unavailable"
                 ) : (
                   "Sign Up"
                 )}
               </motion.button>
+            </fieldset>
             </form>
 
             <p className="mt-6 text-center text-sm text-[#727d77]">

--- a/frontend/src/app/(auth)/signup/SignUpForm.tsx
+++ b/frontend/src/app/(auth)/signup/SignUpForm.tsx
@@ -171,7 +171,7 @@ function PhoneField({
 
 // ── Main sign-up form ─────────────────────────────────────────────────────────
 
-const REGISTRATION_DISABLED = true;
+const REGISTRATION_DISABLED = process.env.NEXT_PUBLIC_REGISTRATION_DISABLED === "true";
 
 export default function SignUpForm() {
   const { signUp, error, isLoading, clearError, fieldErrors, pendingSignupData } =


### PR DESCRIPTION
## Summary
This PR adds the ability to disable user registration when the email service is not available, preventing users from signing up when critical email-dependent features (verification, password reset) cannot function.

## Key Changes
- **Frontend**: Added `NEXT_PUBLIC_REGISTRATION_DISABLED` environment variable to conditionally disable the sign-up form
  - Display an informational banner explaining why registration is offline
  - Disable all form fields using a `<fieldset>` wrapper
  - Update submit button text and disable state based on registration availability
  
- **Backend**: Made email sending non-blocking by wrapping in try-catch blocks
  - Verification email failures no longer block signup completion
  - Welcome email failures no longer block email verification completion
  - Errors are logged for debugging purposes

- **Documentation**: Updated README with prominent warning about registration being offline and email service dependency

- **Configuration**: Added `NEXT_PUBLIC_REGISTRATION_DISABLED` to `.env.example` with usage instructions

## Implementation Details
- The frontend checks the environment variable at module load time to determine registration state
- When disabled, the form remains visible but non-interactive with reduced opacity (60%)
- Backend email errors are gracefully handled to allow the signup flow to complete even if email delivery fails
- This allows the project to be deployed without a working email service while clearly communicating the limitation to users

https://claude.ai/code/session_01K4fjRBrGbwKhAC2RjCNG19